### PR TITLE
Dev lacp

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -47,6 +47,8 @@ jobs:
           git add -f artifacts/open-traffic-generator-isis.txt
           git add -f artifacts/open-traffic-generator-flow.txt
           git add -f artifacts/open-traffic-generator-discovery.txt
+          git add -f artifacts/open-traffic-generator-lag.txt
+          git add -f artifacts/open-traffic-generator-lacp.txt
           if git status --porcelain | grep .
             then
               git commit -m "Update auto generated content"

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ generate: lint ## go generation target
 		-path_structs_output_file=pkg/telemetry/device/device.go \
 		-split_pathstructs_by_module=true \
 		-schema_struct_path=github.com/open-traffic-generator/ixia-c-gnmi-server/pkg/telemetry \
-		-trim_path_package_oc_prefix=true \
 		-path_struct_package_suffix="" \
 		-base_import_path=github.com/open-traffic-generator/ixia-c-gnmi-server/pkg/telemetry \
 		-path_structs_split_files_count=3 \

--- a/artifacts/open-traffic-generator-lacp.txt
+++ b/artifacts/open-traffic-generator-lacp.txt
@@ -1,0 +1,23 @@
+module: open-traffic-generator-lacp
+  +--ro lacp
+     +--ro lag-members
+        +--ro lag-member* [name]
+           +--ro name     -> ../state/name
+           +--ro state
+              +--ro name?               string
+              +--ro activity?           lacp-activity-type
+              +--ro timeout?            lacp-timeout-type
+              +--ro synchronization?    lacp-synchronization-type
+              +--ro aggregatable?       boolean
+              +--ro collecting?         boolean
+              +--ro distributing?       boolean
+              +--ro system-id?          otg-types:mac-address
+              +--ro oper-key?           uint16
+              +--ro partner-id?         otg-types:mac-address
+              +--ro partner-key?        uint16
+              +--ro port-num?           uint16
+              +--ro partner-port-num?   uint16
+              +--ro counters
+                 +--ro lacp-in-pkts?     otg-types:counter64
+                 +--ro lacp-out-pkts?    otg-types:counter64
+                 +--ro lacp-rx-errors?   otg-types:counter64

--- a/artifacts/open-traffic-generator-lag.txt
+++ b/artifacts/open-traffic-generator-lag.txt
@@ -1,0 +1,15 @@
+module: open-traffic-generator-lag
+  +--rw lags
+     +--ro lag* [name]
+        +--ro name     -> ../state/name
+        +--ro state
+           +--ro name?          string
+           +--ro oper-status?   enumeration
+           +--ro out-rate?      otg-types:ieeefloat32
+           +--ro in-rate?       otg-types:ieeefloat32
+           +--ro counters
+              +--ro member-ports-up?   otg-types:counter64
+              +--ro out-octets?        otg-types:counter64
+              +--ro in-octets?         otg-types:counter64
+              +--ro out-frames?        otg-types:counter64
+              +--ro in-frames?         otg-types:counter64

--- a/models/lacp/open-traffic-generator-lacp.yang
+++ b/models/lacp/open-traffic-generator-lacp.yang
@@ -1,0 +1,281 @@
+module open-traffic-generator-lacp {
+  yang-version "1";
+
+  namespace "http://github.com/open-traffic-generator/models/yang/models/lacp";
+  prefix "otg-lacp";
+
+  import open-traffic-generator-types {
+    prefix "otg-types";
+  }
+
+  organization
+    "OpenTrafficGenerator working group";
+
+  contact
+    "OpenTrafficGenerator working group
+     opentrafficgenerator@googlegroups.com";
+
+  description
+    "This module defines telemetry that relates to LACP sessions that
+    are controlled by an open traffic generator (OTG) whose definition
+    is outside of the context of this module.";
+
+  revision 2022-06-08 {
+    description "Initial revision.";
+    reference "0.1.0";
+  }
+
+  // typedef statements
+
+  typedef lacp-activity-type {
+    type enumeration {
+      enum ACTIVE {
+        description
+          "Interface is an active member, i.e., will detect and
+          maintain aggregates";
+      }
+      enum PASSIVE {
+        description
+          "Interface is a passive member, i.e., it participates
+          with an active partner";
+      }
+    }
+    description
+      "Describes the LACP membership type, active or passive, of the
+      interface in the aggregate";
+    reference "IEEE 802.1AX-2008";
+  }
+
+  typedef lacp-timeout-type {
+    type enumeration {
+      enum LONG {
+        description
+          "Participant wishes to use long timeouts to detect
+          status of the aggregate, i.e., will expect less frequent
+          transmissions. Long timeout is 90 seconds.";
+      }
+      enum SHORT {
+        description
+          "Participant wishes to use short timeouts, i.e., expects
+          frequent transmissions to aggressively detect status
+          changes. Short timeout is 3 seconds.";
+      }
+    }
+    description
+      "Type of timeout used, short or long, by LACP participants";
+    reference "IEEE 802.1AX-2008";
+  }
+
+  typedef lacp-synchronization-type {
+    type enumeration {
+      enum IN_SYNC {
+        description
+          "Participant is in sync with the system id and key
+          transmitted";
+      }
+      enum OUT_SYNC {
+        description
+          "Participant is not in sync with the system id and key
+          transmitted";
+      }
+    }
+    description
+      "Indicates LACP synchronization state of participant";
+    reference "IEEE 802.1AX-2008";
+  }
+
+  typedef lacp-period-type {
+    type enumeration {
+      enum FAST {
+        description "Send LACP packets every second";
+      }
+      enum SLOW {
+        description "Send LACP packets every 30 seconds";
+      }
+    }
+    description
+      "Defines the period options for the time between sending
+      LACP messages";
+    reference "IEEE 802.3ad";
+  }
+
+  // grouping statements
+  grouping lacp-top {
+    description
+      "Top-level structural grouping for LACP session telemetry
+      entries.";
+
+    container lacp {
+        config false;
+
+        description
+        "LACP telemetry collected by the ATE device.";
+
+        uses lag-member-top;
+    }
+  }
+
+  grouping lag-member-top {
+    description
+      "Top-level structural grouping for LACP session telemetry for LAG-member
+      entries.";
+
+    container lag-members {
+      description
+        "LACP telemetry for LAG-member collected by the ATE device.";
+
+      list lag-member {
+        key "name";
+
+        config false;
+
+        description
+          "Each LAG member (port) is identified by an arbitrary string
+          identifier.";
+
+        leaf name {
+          type leafref {
+            path "../state/name";
+          }
+          description
+            "Reference to the LAG member's name, acting as a key of the
+            LAG member list controlled by LACP.";
+        }
+
+        container state {
+          config false;
+
+          description
+            "Operational state of an individual LACP peer.";
+
+          uses lacp-state;
+
+          container counters {
+            description
+              "Counters of an individual LACP peer.";
+
+            uses lacp-counters;
+          }
+        }
+      }
+    }
+  }
+
+  grouping lacp-state {
+    description
+      "Operational state of the individual LACP peer.";
+
+    leaf name {
+      type string;
+      description
+        "An arbitary name of the LACP peer determined by the ATE
+        configuration.";
+    }
+    leaf activity {
+      type lacp-activity-type;
+      description "Indicates participant is active or passive";
+    }
+
+    leaf timeout {
+      type lacp-timeout-type;
+      description
+        "The timeout type (short or long) used by the
+        participant";
+    }
+
+    leaf synchronization {
+      type lacp-synchronization-type;
+      description
+        "Indicates whether the participant is in-sync or
+        out-of-sync";
+    }
+
+    leaf aggregatable {
+      type boolean;
+      description
+        "A true value indicates that the participant will allow
+        the link to be used as part of the aggregate. A false
+        value indicates the link should be used as an individual
+        link";
+    }
+
+    leaf collecting {
+      type boolean;
+      description
+        "If true, the participant is collecting incoming frames
+        on the link, otherwise false";
+    }
+
+    leaf distributing {
+      type boolean;
+      description
+        "When true, the participant is distributing outgoing
+        frames; when false, distribution is disabled";
+    }
+
+    leaf system-id {
+      type otg-types:mac-address;
+      description
+        "MAC address that defines the local system ID for the
+        aggregate interface";
+    }
+
+    leaf oper-key {
+      type uint16;
+      description
+        "Current operational value of the key for the aggregate
+        interface";
+    }
+
+    leaf partner-id {
+      type otg-types:mac-address;
+      description
+        "MAC address representing the protocol partner's interface
+        system ID";
+    }
+
+    leaf partner-key {
+      type uint16;
+      description
+        "Operational value of the protocol partner's key";
+    }
+
+    leaf port-num {
+      type uint16;
+      description
+        "Port number of the local (actor) aggregation member";
+    }
+
+    leaf partner-port-num {
+      type uint16;
+      description
+        "Port number of the partner (remote) port for this member
+        port";
+    }
+  }
+
+  grouping lacp-counters {
+    description
+      "Counters of an indivdual LACP session.";
+
+    leaf lacp-in-pkts {
+      type otg-types:counter64;
+      description
+        "The total number of LACPDUs received.";
+    }
+
+    leaf lacp-out-pkts {
+      type otg-types:counter64;
+      description
+        "The total number of LACPDUs transmitted.";
+    }
+
+    leaf lacp-rx-errors {
+      type otg-types:counter64;
+      description
+        "The total number of LACPDUs receive packet errors.";
+    }
+  }
+
+  uses lacp-top;
+}

--- a/models/lag/open-traffic-generator-lag.yang
+++ b/models/lag/open-traffic-generator-lag.yang
@@ -1,0 +1,149 @@
+module open-traffic-generator-lag {
+  yang-version "1";
+
+  namespace "http://github.com/open-traffic-generator/models/yang/models/otg-lag";
+  prefix "otg-lag";
+
+  import open-traffic-generator-types {
+    prefix "otg-types";
+  }
+
+  organization
+    "OpenTrafficGenerator working group";
+
+  contact
+    "OpenTrafficGenerator working group
+     opentrafficgenerator@googlegroups.com";
+
+  description
+    "This module defines telemetry that relates to lags that are
+    defined by an open traffic generator (OTG) whose definition
+    is outside of the context of this module.";
+
+  revision 2022-06-08 {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  grouping lag-top {
+    description
+      "Top-level structural grouping for OTG lag entries.";
+
+    container lags {
+      description
+        "LAGs that are defined by an OTG.";
+
+      list lag {
+        key "name";
+
+        config false;
+
+        description
+          "An individual LAG defined by an OTG.";
+
+        leaf name {
+          type leafref {
+            path "../state/name";
+          }
+          description
+            "Reference to an LAG's name, acting as a key of
+            the LAGs list.";
+        }
+
+        container state {
+          description
+            "Operational state of an individual LAG.";
+          uses lag-state;
+        }
+      }
+    }
+  }
+
+  grouping lag-state {
+    description
+      "Operational state of an OTG lag.";
+
+    leaf name {
+      type string;
+      description
+        "An arbitary name of an OTG LAG determined by the OTG
+        configuration.";
+    }
+
+    leaf oper-status {
+      type enumeration {
+        enum UP {
+          description
+            "Indicates member ports >= min_links are in UP state";
+        }
+        enum DOWN {
+          description
+            "Indicates member ports < min_links are in UP state";
+        }
+      }
+
+      description
+        "The current operational state of an OTG LAG.";
+    }
+
+    leaf out-rate {
+      type otg-types:ieeefloat32;
+      units "bps";
+      description
+        "The current transmit rate of an OTG LAG, measured in
+        bits per second.";
+    }
+
+    leaf in-rate {
+      type otg-types:ieeefloat32;
+      units "bps";
+      description
+        "The current receive rate of an OTG LAG, measured in
+        bits per second.";
+    }
+
+    container counters {
+      description
+        "Counters of an OTG LAG.";
+      uses lag-counters;
+    }
+  }
+
+  grouping lag-counters {
+    description
+      "Counters of an OTG LAG.";
+
+      leaf member-ports-up {
+        type otg-types:counter64;
+        description
+          "The current *-number of member ports on the LAG in UP state.";
+      }
+
+      leaf out-octets {
+        type otg-types:counter64;
+        description
+          "The total number of octets transmitted on the LAG.";
+      }
+
+      leaf in-octets {
+        type otg-types:counter64;
+        description
+          "The total number of octets received on the LAG.";
+      }
+
+      leaf out-frames {
+        type otg-types:counter64;
+        description
+          "The total number of packets transmitted on the LAG.";
+      }
+
+      leaf in-frames {
+        type otg-types:counter64;
+        description
+          "The total number of packets received on the LAG.";
+      }
+  }
+
+  uses lag-top;
+}


### PR DESCRIPTION
The current OTG yang models need to support telemetry for LAG and LACP.
The proposed model can be viewed here:
    LAG: https://github.com/open-traffic-generator/models-yang/blob/dev-lacp/artifacts/open-traffic-generator-lag.txt
    LACP: https://github.com/open-traffic-generator/models-yang/blob/dev-lacp/artifacts/open-traffic-generator-lacp.txt