### PR TITLE
Flow tracking

### DIFF
--- a/artifacts/open-traffic-generator-flow.txt
+++ b/artifacts/open-traffic-generator-flow.txt
@@ -1,31 +1,31 @@
 module: open-traffic-generator-flow
   +--rw flows
      +--ro flow* [name]
-     |  +--ro name     -> ../state/name
-     |  +--ro state
-     |     +--ro name?             string
-     |     +--ro transmit?         boolean
-     |     +--ro loss-pct?         otg-types:ieeefloat32
-     |     +--ro out-frame-rate?   otg-types:ieeefloat32
-     |     +--ro in-frame-rate?    otg-types:ieeefloat32
-     |     +--ro out-rate?         otg-types:ieeefloat32
-     |     +--ro in-rate?          otg-types:ieeefloat32
-     |     +--ro counters
-     |        +--ro in-octets?    otg-types:counter64
-     |        +--ro in-pkts?      otg-types:counter64
-     |        +--ro out-octets?   otg-types:counter64
-     |        +--ro out-pkts?     otg-types:counter64
-     +--rw flow-metric-tags
-        +--rw flow-metric-tag* [name-value-request]
-           +--rw name-value-request    -> ../state/name-value-request
-           +--rw state
-              +--rw name-value-request?   string
-              +--rw metric* [name-value-response]
-                 +--rw name-value-response    -> ../state/name-value-response
-                 +--rw state
-                    +--rw name-value-response?   string
-                    +--rw counters
-                       +--rw in-octets?    otg-types:counter64
-                       +--rw in-pkts?      otg-types:counter64
-                       +--rw out-octets?   otg-types:counter64
-                       +--rw out-pkts?     otg-types:counter64
+        +--ro name                -> ../state/name
+        +--ro state
+        |  +--ro name?             string
+        |  +--ro transmit?         boolean
+        |  +--ro loss-pct?         otg-types:ieeefloat32
+        |  +--ro out-frame-rate?   otg-types:ieeefloat32
+        |  +--ro in-frame-rate?    otg-types:ieeefloat32
+        |  +--ro out-rate?         otg-types:ieeefloat32
+        |  +--ro in-rate?          otg-types:ieeefloat32
+        |  +--ro counters
+        |     +--ro in-octets?    otg-types:counter64
+        |     +--ro in-pkts?      otg-types:counter64
+        |     +--ro out-octets?   otg-types:counter64
+        |     +--ro out-pkts?     otg-types:counter64
+        +--ro flow-metric-tags
+           +--ro flow-metric-tag* [name-value-request]
+              +--ro name-value-request    -> ../state/name-value-request
+              +--ro state
+                 +--ro name-value-request?   string
+                 +--ro metric* [name-value-response]
+                    +--ro name-value-response    -> ../state/name-value-response
+                    +--ro state
+                       +--ro name-value-response?   string
+                       +--ro counters
+                          +--ro in-octets?    otg-types:counter64
+                          +--ro in-pkts?      otg-types:counter64
+                          +--ro out-octets?   otg-types:counter64
+                          +--ro out-pkts?     otg-types:counter64

--- a/artifacts/open-traffic-generator-flow.txt
+++ b/artifacts/open-traffic-generator-flow.txt
@@ -1,7 +1,7 @@
 module: open-traffic-generator-flow
   +--rw flows
      +--ro flow* [name]
-        +--ro name                -> ../state/name
+        +--ro name               -> ../state/name
         +--ro state
         |  +--ro name?             string
         |  +--ro transmit?         boolean
@@ -15,17 +15,16 @@ module: open-traffic-generator-flow
         |     +--ro in-pkts?      otg-types:counter64
         |     +--ro out-octets?   otg-types:counter64
         |     +--ro out-pkts?     otg-types:counter64
-        +--ro flow-metric-tags
-           +--ro flow-metric-tag* [name-value-request]
-              +--ro name-value-request    -> ../state/name-value-request
-              +--ro state
-                 +--ro name-value-request?   string
-                 +--ro metric* [name-value-response]
-                    +--ro name-value-response    -> ../state/name-value-response
-                    +--ro state
-                       +--ro name-value-response?   string
-                       +--ro counters
-                          +--ro in-octets?    otg-types:counter64
-                          +--ro in-pkts?      otg-types:counter64
-                          +--ro out-octets?   otg-types:counter64
-                          +--ro out-pkts?     otg-types:counter64
+        +--ro flow-metric-tag* [name-value-request]
+           +--ro name-value-request    -> ../state/name-value-request
+           +--ro state
+              +--ro name-value-request?   string
+              +--ro metric* [name-value-response]
+                 +--ro name-value-response    -> ../state/name-value-response
+                 +--ro state
+                    +--ro name-value-response?   string
+                    +--ro counters
+                       +--ro in-octets?    otg-types:counter64
+                       +--ro in-pkts?      otg-types:counter64
+                       +--ro out-octets?   otg-types:counter64
+                       +--ro out-pkts?     otg-types:counter64

--- a/artifacts/open-traffic-generator-flow.txt
+++ b/artifacts/open-traffic-generator-flow.txt
@@ -1,17 +1,31 @@
 module: open-traffic-generator-flow
   +--rw flows
      +--ro flow* [name]
-        +--ro name     -> ../state/name
-        +--ro state
-           +--ro name?             string
-           +--ro transmit?         boolean
-           +--ro loss-pct?         otg-types:ieeefloat32
-           +--ro out-frame-rate?   otg-types:ieeefloat32
-           +--ro in-frame-rate?    otg-types:ieeefloat32
-           +--ro out-rate?         otg-types:ieeefloat32
-           +--ro in-rate?          otg-types:ieeefloat32
-           +--ro counters
-              +--ro in-octets?    otg-types:counter64
-              +--ro in-pkts?      otg-types:counter64
-              +--ro out-octets?   otg-types:counter64
-              +--ro out-pkts?     otg-types:counter64
+     |  +--ro name     -> ../state/name
+     |  +--ro state
+     |     +--ro name?             string
+     |     +--ro transmit?         boolean
+     |     +--ro loss-pct?         otg-types:ieeefloat32
+     |     +--ro out-frame-rate?   otg-types:ieeefloat32
+     |     +--ro in-frame-rate?    otg-types:ieeefloat32
+     |     +--ro out-rate?         otg-types:ieeefloat32
+     |     +--ro in-rate?          otg-types:ieeefloat32
+     |     +--ro counters
+     |        +--ro in-octets?    otg-types:counter64
+     |        +--ro in-pkts?      otg-types:counter64
+     |        +--ro out-octets?   otg-types:counter64
+     |        +--ro out-pkts?     otg-types:counter64
+     +--rw flow-metric-tags
+        +--rw flow-metric-tag* [name-value-request]
+           +--rw name-value-request    -> ../state/name-value-request
+           +--rw state
+              +--rw name-value-request?   string
+              +--rw metric* [name-value-response]
+                 +--rw name-value-response    -> ../state/name-value-response
+                 +--rw state
+                    +--rw name-value-response?   string
+                    +--rw counters
+                       +--rw in-octets?    otg-types:counter64
+                       +--rw in-pkts?      otg-types:counter64
+                       +--rw out-octets?   otg-types:counter64
+                       +--rw out-pkts?     otg-types:counter64

--- a/models/flow/open-traffic-generator-flow.yang
+++ b/models/flow/open-traffic-generator-flow.yang
@@ -83,7 +83,7 @@ module open-traffic-generator-flow {
     leaf name {
       type string;
       description
-        "An arbitary name used for the flow tracked by the system. This
+        "An arbitrary name used for the flow tracked by the system. This
         name must be unique for the flows tracked and exported by the target.";
     }
 
@@ -166,61 +166,82 @@ module open-traffic-generator-flow {
 
     container flow-metric-tags {
       description
-        "Metric Tags of a Flow";
+        "Container of flow-metric-tags information";
 
       list flow-metric-tag {
         key "name-value-request";
 
         description
-          "A list of Flow Metric Tag";
+          "A list of flow-metric-tag which represent one or more metric tags (request)
+              to disaggregate flow metrics and associated disaggregated flow metrics (response).
+              Each flow-metric-tag is identified by a name-value-request.";
 
         leaf name-value-request {
           type leafref {
             path "../state/name-value-request";
           }
           description
-            "Reference to a name-value-request, acting as part
-            of a key to the flow-metric-tag list.";
+            "Reference to a name-value-request, acting as
+            a key to the flow-metric-tag list.";
         }
 
         container state {
           description
-            "The container for metric-tag state.";
+            "Operational state of the individual flow-metric-tag.";
 
           leaf name-value-request {
             type string;
             description
-              "The name-value-request.";
+              "Encoded string representing one or more metric tag name and corresponding filter value
+              used as request to disaggregate the flow metrics.
+              Encoding format:
+                  tag_name=value&tag_name=value
+                  name can be specified multiple times.
+                  value is optional, need to be supplied only for retrieving subset of disaggregated flow metrics
+                  matching with the tag name and value.
+              Example:
+                  ipv4_src&vlan_id
+                  ipv4_src=0x11&vlan_id=0x01
+                  ipv4_src=0x11&ipv4_src=0x12&vlan_id=0x01";
           }
 
           list metric {
             key "name-value-response";
 
             description
-              "A list of metric.";
+              "A list of disaggregated flow metric, based on metric tags & values specified in name-value-request.
+              Each disaggregated flow metric is identified by a name-value-response";
 
             leaf name-value-response {
               type leafref {
                 path "../state/name-value-response";
               }
               description
-                "Reference to a name-value-response, acting as part
-                of a key to the metric list.";
+                "Reference to a name-value-response, acting as
+                a key of the metric list.";
             }
 
             container state {
               description
-                "The container for metric state.";
+                "Operational state of the individual metric.";
 
               leaf name-value-response {
                 type string;
                 description
-                  "The name-value-response.";
+                  "Encoded string represents one or more metric tag name and corresponding tag value,
+                  to identify each disaggregated flow.
+                  Encoding format:
+                      tag_name=value&tag_name=value
+                  Example:
+                      ipv4_src=0x11
+                      ipv4_src=0x11&vlan_id=0x01
+                      ipv4_src=0x12&vlan_id=0x01";
               }
 
               container counters {
                 description
-                  "Counters that correspond to the individual metric.";
+                  "Counters that correspond to the disaggregated flow metrics associated
+                  with a name-value-response as identifier of that disaggregated flow.";
 
                 uses flow-counters;
               }

--- a/models/flow/open-traffic-generator-flow.yang
+++ b/models/flow/open-traffic-generator-flow.yang
@@ -71,6 +71,8 @@ module open-traffic-generator-flow {
           }
         }
       }
+
+      uses flow-metric-tags;
     }
   }
 
@@ -155,6 +157,77 @@ module open-traffic-generator-flow {
       description
         "The total number of packets sent by the target for the flow. These
         packets may be generated or forwarded by the target.";
+    }
+  }
+
+  grouping flow-metric-tags {
+    description
+      "Structural grouping for flow-metric-tags information";
+
+    container flow-metric-tags {
+      description
+        "Metric Tags of a Flow";
+
+      list flow-metric-tag {
+        key "name-value-request";
+
+        description
+          "A list of Flow Metric Tag";
+
+        leaf name-value-request {
+          type leafref {
+            path "../state/name-value-request";
+          }
+          description
+            "Reference to a name-value-request, acting as part
+            of a key to the flow-metric-tag list.";
+        }
+
+        container state {
+          description
+            "The container for metric-tag state.";
+
+          leaf name-value-request {
+            type string;
+            description
+              "The name-value-request.";
+          }
+
+          list metric {
+            key "name-value-response";
+
+            description
+              "A list of metric.";
+
+            leaf name-value-response {
+              type leafref {
+                path "../state/name-value-response";
+              }
+              description
+                "Reference to a name-value-response, acting as part
+                of a key to the metric list.";
+            }
+
+            container state {
+              description
+                "The container for metric state.";
+
+              leaf name-value-response {
+                type string;
+                description
+                  "The name-value-response.";
+              }
+
+              container counters {
+                description
+                  "Counters that correspond to the individual metric.";
+
+                uses flow-counters;
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/models/flow/open-traffic-generator-flow.yang
+++ b/models/flow/open-traffic-generator-flow.yang
@@ -71,7 +71,7 @@ module open-traffic-generator-flow {
           }
         }
 
-        uses flow-metric-tags;
+        uses flow-metric-tag;
       }
     }
   }
@@ -160,91 +160,87 @@ module open-traffic-generator-flow {
     }
   }
 
-  grouping flow-metric-tags {
+  grouping flow-metric-tag {
     description
-      "Structural grouping for flow-metric-tags information";
+      "Structural grouping for flow-metric-tag information";
 
-    container flow-metric-tags {
+    list flow-metric-tag {
+      key "name-value-request";
+
       description
-        "Container of flow-metric-tags information";
+        "A list of flow-metric-tag which represent one or more metric tags (request)
+            to enumerate flow metrics and associated enumerated flow metrics (response).
+            Each flow-metric-tag is identified by a name-value-request.";
 
-      list flow-metric-tag {
-        key "name-value-request";
-
+      leaf name-value-request {
+        type leafref {
+          path "../state/name-value-request";
+        }
         description
-          "A list of flow-metric-tag which represent one or more metric tags (request)
-              to disaggregate flow metrics and associated disaggregated flow metrics (response).
-              Each flow-metric-tag is identified by a name-value-request.";
+          "Reference to a name-value-request, acting as
+          a key to the flow-metric-tag list.";
+      }
+
+      container state {
+        description
+          "Operational state of the individual flow-metric-tag.";
 
         leaf name-value-request {
-          type leafref {
-            path "../state/name-value-request";
-          }
+          type string;
           description
-            "Reference to a name-value-request, acting as
-            a key to the flow-metric-tag list.";
+            "Encoded string representing one or more metric tag name and corresponding filter value
+            used as request to enumerate the flow metrics.
+            Encoding format:
+                tag_name=value&tag_name=value
+                name can be specified multiple times.
+                value is optional, need to be supplied only for retrieving subset of enumerated flow metrics
+                matching with the tag name and value.
+                The datatype of value can only be hex.
+            Example:
+                ipv4_src&vlan_id
+                ipv4_src=0x11&vlan_id=0x01
+                ipv4_src=0x11&ipv4_src=0x12&vlan_id=0x01";
         }
 
-        container state {
-          description
-            "Operational state of the individual flow-metric-tag.";
+        list metric {
+          key "name-value-response";
 
-          leaf name-value-request {
-            type string;
+          description
+            "A list of enumerated flow metric, based on metric tags & values specified in name-value-request.
+            Each enumerated flow metric is identified by a name-value-response";
+
+          leaf name-value-response {
+            type leafref {
+              path "../state/name-value-response";
+            }
             description
-              "Encoded string representing one or more metric tag name and corresponding filter value
-              used as request to disaggregate the flow metrics.
-              Encoding format:
-                  tag_name=value&tag_name=value
-                  name can be specified multiple times.
-                  value is optional, need to be supplied only for retrieving subset of disaggregated flow metrics
-                  matching with the tag name and value.
-              Example:
-                  ipv4_src&vlan_id
-                  ipv4_src=0x11&vlan_id=0x01
-                  ipv4_src=0x11&ipv4_src=0x12&vlan_id=0x01";
+              "Reference to a name-value-response, acting as
+              a key of the metric list.";
           }
 
-          list metric {
-            key "name-value-response";
-
+          container state {
             description
-              "A list of disaggregated flow metric, based on metric tags & values specified in name-value-request.
-              Each disaggregated flow metric is identified by a name-value-response";
+              "Operational state of the individual metric.";
 
             leaf name-value-response {
-              type leafref {
-                path "../state/name-value-response";
-              }
+              type string;
               description
-                "Reference to a name-value-response, acting as
-                a key of the metric list.";
+                "Encoded string represents one or more metric tag name and corresponding tag value,
+                to identify each enumerated flow.
+                Encoding format:
+                    tag_name=value&tag_name=value
+                Example:
+                    ipv4_src=0x11
+                    ipv4_src=0x11&vlan_id=0x01
+                    ipv4_src=0x12&vlan_id=0x01";
             }
 
-            container state {
+            container counters {
               description
-                "Operational state of the individual metric.";
+                "Counters that correspond to the enumerated flow metrics associated
+                with a name-value-response as identifier of that enumerated flow.";
 
-              leaf name-value-response {
-                type string;
-                description
-                  "Encoded string represents one or more metric tag name and corresponding tag value,
-                  to identify each disaggregated flow.
-                  Encoding format:
-                      tag_name=value&tag_name=value
-                  Example:
-                      ipv4_src=0x11
-                      ipv4_src=0x11&vlan_id=0x01
-                      ipv4_src=0x12&vlan_id=0x01";
-              }
-
-              container counters {
-                description
-                  "Counters that correspond to the disaggregated flow metrics associated
-                  with a name-value-response as identifier of that disaggregated flow.";
-
-                uses flow-counters;
-              }
+              uses flow-counters;
             }
           }
         }

--- a/models/flow/open-traffic-generator-flow.yang
+++ b/models/flow/open-traffic-generator-flow.yang
@@ -70,9 +70,9 @@ module open-traffic-generator-flow {
             uses flow-counters;
           }
         }
-      }
 
-      uses flow-metric-tags;
+        uses flow-metric-tags;
+      }
     }
   }
 


### PR DESCRIPTION
Proposed model for flows, with a new tree node `flow-metric-tag`:
```
module: open-traffic-generator-flow
  +--rw flows
     +--ro flow* [name]
        +--ro name               -> ../state/name
        +--ro state
        |  +--ro name?             string
        |  +--ro transmit?         boolean
        |  +--ro loss-pct?         otg-types:ieeefloat32
        |  +--ro out-frame-rate?   otg-types:ieeefloat32
        |  +--ro in-frame-rate?    otg-types:ieeefloat32
        |  +--ro out-rate?         otg-types:ieeefloat32
        |  +--ro in-rate?          otg-types:ieeefloat32
        |  +--ro counters
        |     +--ro in-octets?    otg-types:counter64
        |     +--ro in-pkts?      otg-types:counter64
        |     +--ro out-octets?   otg-types:counter64
        |     +--ro out-pkts?     otg-types:counter64
        +--ro flow-metric-tag* [name-value-request]
           +--ro name-value-request    -> ../state/name-value-request
           +--ro state
              +--ro name-value-request?   string
              +--ro metric* [name-value-response]
                 +--ro name-value-response    -> ../state/name-value-response
                 +--ro state
                    +--ro name-value-response?   string
                    +--ro counters
                       +--ro in-octets?    otg-types:counter64
                       +--ro in-pkts?      otg-types:counter64
                       +--ro out-octets?   otg-types:counter64
                       +--ro out-pkts?     otg-types:counter64
```

Assuming the following packet distribution for flow `F1`, some example gNMI query and results are described below:

![image](https://user-images.githubusercontent.com/79712606/227249267-5d3a41c6-9f36-4fff-8300-9f41bc967280.png)

### 1. Only the aggregated per-flow stats:
gNMI query path: “/flows/flow[name=F1]/”
gNMI response:
```
"updates": [
   {
      "Path": "flows/flow[name=f1]",
      "values": {
         "flows/flow": {
            "open-traffic-generator-flow:name": "f1",
            "open-traffic-generator-flow:state": {
               "counters": {                                       // Contains the aggregated per-flow stats
                  "in-octets": "2400",
                  "in-pkts": "300",
                  "out-octets": "2400",
                  "out-pkts": "300"
               },
               "in-frame-rate": "QKAAAA==",
               "name": "f1",
               "out-frame-rate": "QCAAAA==",
               "transmit": true
            }                                                             // Note: disaggregated stats is missing
         }
      }
   }
]
```

### 2. Disaggregated (drill-down) stats for all VLAN IDs:
gNMI query path: “/flows/flow[name=F1]/flow-metric-tag[name-value-request=’vlan’]”
gNMI response:

```
   "updates": [
   {
      "Path": "flows/flow[name=f1]/flow-metric-tag[name-value-request='vlan']",
      "values": {
         "flows/flow/flow-metric-tag": {
            "open-traffic-generator-flow:name-value-request": "vlan",
            "open-traffic-generator-flow:state": {
               "name-value-request": "vlan",
               "metric": [
                  {
                     "name-value-response": "vlan=0x64",        // enumerated to name/value of VLAN ID = 100
                     "counters": {
                        "in-octets": "2000",
                        "in-pkts": "250",
                     }                     
                  },
                  {
                     "name-value-response": "vlan=0xCE",        // enumerated to name/value of VLAN ID = 200
                     "counters": {
                        "in-octets": "400",
                        "in-pkts": "50",
                     }                     
                  }
               ]
         }
      }
   }
]             
```
### 3. Disaggregated stats for VLAN ID = 200:
gNMI query path: “/flows/flow[name=F1]/flow-metric-tag[name-value-request=’vlan=0xCE’]”
gNMI response:
```
   "updates": [
   {
      "Path": "flows/flow[name=f1]/flow-metric-tag[name-value-request='vlan=0xCE']",
      "values": {
         "flows/flow/flow-metric-tag": {
            "open-traffic-generator-flow:name-value-request": "vlan=0xCE",
            "open-traffic-generator-flow:state": {
               "name-value-request": "vlan=0xCE",
               "metric": [
                  {
                     "name-value-response": "vlan=0xCE",        // name/value filtered for VLAN ID = 200
                     "counters": {
                        "in-octets": "400",
                        "in-pkts": "50",
                     }                     
                  }
               ]
         }
      }
   }
]             
```

### 4. Disaggregated stats for all VLAN IDs&Src IP (multi-field tracking):
gNMI query path: “/flows/flow[name=F1]/flow-metric-tag[name-value-request=’vlan&srcip’]”
gNMI response:
```
   "updates": [
   {
      "Path": "flows/flow[name=f1]/flow-metric-tag[name-value-request='vlan&srcip']",
      "values": {
         "flows/flow/flow-metric-tag": {
            "open-traffic-generator-flow:name-value-request": "vlan&srcip",
            "open-traffic-generator-flow:state": {
               "name-value-request": "vlan&srcip",
               "metric": [
                  {
                     "name-value-response": "vlan=0x64&srcip=0x1",   // row for VLAN ID = 100 & Src IP = 10.10.10.1
                     "counters": {
                        "in-octets": "800",
                        "in-pkts": "100",
                     }                     
                  },
                  {
                     "name-value-response": "vlan=0x64&srcip=0x2",   // row for VLAN ID = 100 & Src IP = 10.10.10.2
                     "counters": {
                        "in-octets": "1200",
                        "in-pkts": "150",
                     }                     
                 },
                 {
                     "name-value-response": "vlan=0xCE&srcip=0x1",  // row for VLAN ID = 200 & Src IP = 10.10.10.1
                     "counters": {
                        "in-octets": "160",
                        "in-pkts": "20",
                     }                     
                 },
                 {
                     "name-value-response": "vlan=0xCE&srcip=0x1",  // row for VLAN ID = 200 & Src IP = 10.10.10.2
                     "counters": {
                        "in-octets": "240",
                        "in-pkts": "30",
                     }                     
                 }
               ]
         }
      }
   }
]             
```
**Note:** _Assumption, Metric Tag for Src IP is configured only for the last 8 bits. Hence IP Src address is matched for the last 8 bits appearing in the result._ 

### 5. Disaggregated stats for all Src IPs (VLAN ID is ignored):
gNMI query path: “/flows/flow[name=F1]/flow-metric-tag[name-value-request=’srcip’]”
gNMI response:
```
   "updates": [
   {
      "Path": "flows/flow[name=f1]/flow-metric-tag[name-value-request='srcip']",
      "values": {
         "flows/flow/flow-metric-tag": {
            "open-traffic-generator-flow:name-value-request": "srcip",
            "open-traffic-generator-flow:state": {
               "name-value-request": "srcip",
               "metric": [
                  {
                     "name-value-response": "srcip=0x1",  // row(s) for Src IP = 10.10.10.1
                     "counters": {
                        "in-octets": "960",
                        "in-pkts": "120",             // 100 (for VLAN ID = 100) + 20 (for VLAN ID = 200)
                     }                     
                  },
                  {
                     "name-value-response": "srcip=0x2",  // row(s) for Src IP = 10.10.10.2
                     "counters": {
                        "in-octets": "1440",
                        "in-pkts": "180",              // 150 (for VLAN ID = 100) + 30 (for VLAN ID = 200)
                     }                     
                 }
               ]
         }
      }
   }
]             
```