### PR TITLE
Add support of Min/Max/Avg latency in flow metric

### DIFF
--- a/artifacts/open-traffic-generator-flow.txt
+++ b/artifacts/open-traffic-generator-flow.txt
@@ -3,13 +3,16 @@ module: open-traffic-generator-flow
      +--ro flow* [name]
         +--ro name     -> ../state/name
         +--ro state
-           +--ro name?             string
-           +--ro transmit?         boolean
-           +--ro loss-pct?         otg-types:ieeefloat32
-           +--ro out-frame-rate?   otg-types:ieeefloat32
-           +--ro in-frame-rate?    otg-types:ieeefloat32
-           +--ro out-rate?         otg-types:ieeefloat32
-           +--ro in-rate?          otg-types:ieeefloat32
+           +--ro name?              string
+           +--ro transmit?          boolean
+           +--ro loss-pct?          otg-types:ieeefloat32
+           +--ro out-frame-rate?    otg-types:ieeefloat32
+           +--ro in-frame-rate?     otg-types:ieeefloat32
+           +--ro out-rate?          otg-types:ieeefloat32
+           +--ro in-rate?           otg-types:ieeefloat32
+           +--ro minimum-latency?   otg-types:timeticks64
+           +--ro maximum-latency?   otg-types:timeticks64
+           +--ro average-latency?   otg-types:timeticks64
            +--ro counters
               +--ro in-octets?    otg-types:counter64
               +--ro in-pkts?      otg-types:counter64

--- a/models/flow/open-traffic-generator-flow.yang
+++ b/models/flow/open-traffic-generator-flow.yang
@@ -125,6 +125,27 @@ module open-traffic-generator-flow {
         "The rate, measured in bits per second, at which the flow is being
         received.";
     }
+
+    leaf minimum-latency {
+      type otg-types:timeticks64;
+      description
+        "The minimum latency value, measured in nanoseconds. The latency value is dependent
+        on the configured type of latency measurement mode.";
+    }
+
+    leaf maximum-latency {
+      type otg-types:timeticks64;
+      description
+        "The maximum latency value, measured in nanoseconds. The latency value is dependent
+        on the configured type of latency measurement mode.";
+    }
+
+    leaf average-latency {
+      type otg-types:timeticks64;
+      description
+        "The average latency value, measured in nanoseconds. The latency value is dependent
+        on the configured type of latency measurement mode.";
+    }
   }
 
   grouping flow-counters {


### PR DESCRIPTION
Added minimum-latency, maximum-latency and average-latency in following model:
Support for these attributes is already available in OTG models.
```
module: open-traffic-generator-flow
  +--rw flows
     +--ro flow* [name]
        +--ro name     -> ../state/name
        +--ro state
           +--ro name?              string
           +--ro transmit?          boolean
           +--ro loss-pct?          otg-types:ieeefloat32
           +--ro out-frame-rate?    otg-types:ieeefloat32
           +--ro in-frame-rate?     otg-types:ieeefloat32
           +--ro out-rate?          otg-types:ieeefloat32
           +--ro in-rate?           otg-types:ieeefloat32
           +--ro minimum-latency?   otg-types:timeticks64
           +--ro maximum-latency?   otg-types:timeticks64
           +--ro average-latency?   otg-types:timeticks64
           +--ro counters
              +--ro in-octets?    otg-types:counter64
              +--ro in-pkts?      otg-types:counter64
              +--ro out-octets?   otg-types:counter64
              +--ro out-pkts?     otg-types:counter64
```