### PR TITLE
Flow tracking (ver2)

### DIFF
--- a/artifacts/open-traffic-generator-flow.txt
+++ b/artifacts/open-traffic-generator-flow.txt
@@ -1,7 +1,7 @@
 module: open-traffic-generator-flow
   +--rw flows
      +--ro flow* [name]
-        +--ro name               -> ../state/name
+        +--ro name           -> ../state/name
         +--ro state
         |  +--ro name?             string
         |  +--ro transmit?         boolean
@@ -15,16 +15,13 @@ module: open-traffic-generator-flow
         |     +--ro in-pkts?      otg-types:counter64
         |     +--ro out-octets?   otg-types:counter64
         |     +--ro out-pkts?     otg-types:counter64
-        +--ro flow-metric-tag* [name-value-request]
-           +--ro name-value-request    -> ../state/name-value-request
-           +--ro state
-              +--ro name-value-request?   string
-              +--ro metric* [name-value-response]
-                 +--ro name-value-response    -> ../state/name-value-response
-                 +--ro state
-                    +--ro name-value-response?   string
-                    +--ro counters
-                       +--ro in-octets?    otg-types:counter64
-                       +--ro in-pkts?      otg-types:counter64
-                       +--ro out-octets?   otg-types:counter64
-                       +--ro out-pkts?     otg-types:counter64
+        +--ro tag-metrics
+           +--ro tag-metric* [name-value]
+              +--ro name-value    -> ../state/name-value
+              +--ro state
+                 +--ro name-value?   string
+                 +--ro counters
+                    +--ro in-octets?    otg-types:counter64
+                    +--ro in-pkts?      otg-types:counter64
+                    +--ro out-octets?   otg-types:counter64
+                    +--ro out-pkts?     otg-types:counter64

--- a/artifacts/open-traffic-generator-flow.txt
+++ b/artifacts/open-traffic-generator-flow.txt
@@ -20,6 +20,18 @@ module: open-traffic-generator-flow
               +--ro name-value    -> ../state/name-value
               +--ro state
                  +--ro name-value?   string
+                 +--ro tags* []
+                 |  +--ro tag-name?    string
+                 |  +--ro tag-value
+                 |     +--ro value-type?           enumeration
+                 |     +--ro value-as-string?      string
+                 |     +--ro value-as-hex?         otg-types:hex-string
+                 |     +--ro value-as-bool?        boolean
+                 |     +--ro value-as-counter64?   otg-types:counter64
+                 |     +--ro value-as-float32?     otg-types:ieeefloat32
+                 |     +--ro value-as-ipv4?        otg-types:ipv4-address
+                 |     +--ro value-as-ipv6?        otg-types:ipv6-address
+                 |     +--ro value-as-mac?         otg-types:mac-address
                  +--ro counters
                     +--ro in-octets?    otg-types:counter64
                     +--ro in-pkts?      otg-types:counter64

--- a/artifacts/open-traffic-generator-flow.txt
+++ b/artifacts/open-traffic-generator-flow.txt
@@ -1,7 +1,7 @@
 module: open-traffic-generator-flow
   +--rw flows
      +--ro flow* [name]
-        +--ro name           -> ../state/name
+        +--ro name              -> ../state/name
         +--ro state
         |  +--ro name?             string
         |  +--ro transmit?         boolean
@@ -15,11 +15,11 @@ module: open-traffic-generator-flow
         |     +--ro in-pkts?      otg-types:counter64
         |     +--ro out-octets?   otg-types:counter64
         |     +--ro out-pkts?     otg-types:counter64
-        +--ro tag-metrics
-           +--ro tag-metric* [name-value]
-              +--ro name-value    -> ../state/name-value
+        +--ro tagged-metrics
+           +--ro tagged-metric* [name-value-pairs]
+              +--ro name-value-pairs    -> ../state/name-value-pairs
               +--ro state
-                 +--ro name-value?   string
+                 +--ro name-value-pairs?   string
                  +--ro tags* []
                  |  +--ro tag-name?    string
                  |  +--ro tag-value

--- a/models/flow/open-traffic-generator-flow.yang
+++ b/models/flow/open-traffic-generator-flow.yang
@@ -212,8 +212,7 @@ module open-traffic-generator-flow {
 
           list tags {
             description
-              "A list of metric tag names and associated tag values, in a structured manner to identify each enumerated flow.
-              The order of the metric tags in the list is by alphabetical order of the tag name";
+              "A list of metric tag names and associated tag values, in a structured manner to identify each enumerated flow.";
 
             leaf tag-name {
               type string;

--- a/models/flow/open-traffic-generator-flow.yang
+++ b/models/flow/open-traffic-generator-flow.yang
@@ -71,7 +71,7 @@ module open-traffic-generator-flow {
           }
         }
 
-        uses flow-metric-tag;
+        uses tag-metrics;
       }
     }
   }
@@ -160,88 +160,55 @@ module open-traffic-generator-flow {
     }
   }
 
-  grouping flow-metric-tag {
+  grouping tag-metrics {
     description
-      "Structural grouping for flow-metric-tag information";
+      "Structural grouping for tag-metrics information";
 
-    list flow-metric-tag {
-      key "name-value-request";
-
+    container tag-metrics {
       description
-        "A list of flow-metric-tag which represent one or more metric tags (request)
+        "A list of tag-metrics which represent one or more metric tags (request)
             to enumerate flow metrics and associated enumerated flow metrics (response).
-            Each flow-metric-tag is identified by a name-value-request.";
+            Each tag-metrics is identified by a name-value-request.";
 
-      leaf name-value-request {
-        type leafref {
-          path "../state/name-value-request";
-        }
+      list tag-metric {
+        key "name-value";
+
         description
-          "Reference to a name-value-request, acting as
-          a key to the flow-metric-tag list.";
-      }
+          "A list of enumerated flow metric, based on metric tags in the configuration.
+          Each enumerated flow metric is identified by a name-value";
 
-      container state {
-        description
-          "Operational state of the individual flow-metric-tag.";
-
-        leaf name-value-request {
-          type string;
+        leaf name-value {
+          type leafref {
+            path "../state/name-value";
+          }
           description
-            "Encoded string representing one or more metric tag name and corresponding filter value
-            used as request to enumerate the flow metrics.
-            Encoding format:
-                tag_name=value&tag_name=value
-                name can be specified multiple times.
-                value is optional, need to be supplied only for retrieving subset of enumerated flow metrics
-                matching with the tag name and value.
-                The datatype of value can only be hex.
-            Example:
-                ipv4_src&vlan_id
-                ipv4_src=0x11&vlan_id=0x01
-                ipv4_src=0x11&ipv4_src=0x12&vlan_id=0x01";
+            "Reference to a name-value, acting as
+            a key of the tag-metric list.";
         }
 
-        list metric {
-          key "name-value-response";
-
+        container state {
           description
-            "A list of enumerated flow metric, based on metric tags & values specified in name-value-request.
-            Each enumerated flow metric is identified by a name-value-response";
+            "Operational state of the individual metric.";
 
-          leaf name-value-response {
-            type leafref {
-              path "../state/name-value-response";
-            }
+          leaf name-value {
+            type string;
             description
-              "Reference to a name-value-response, acting as
-              a key of the metric list.";
+              "Encoded string represents one or more metric tag name and corresponding tag value,
+              to identify each enumerated flow.
+              Encoding format:
+                  tag_name=value&tag_name=value
+              Example:
+                  ipv4_src=0x11
+                  ipv4_src=0x11&vlan_id=0x01
+                  ipv4_src=0x12&vlan_id=0x01";
           }
 
-          container state {
+          container counters {
             description
-              "Operational state of the individual metric.";
+              "Counters that correspond to the enumerated flow metrics associated
+              with a name-value as identifier of that enumerated flow.";
 
-            leaf name-value-response {
-              type string;
-              description
-                "Encoded string represents one or more metric tag name and corresponding tag value,
-                to identify each enumerated flow.
-                Encoding format:
-                    tag_name=value&tag_name=value
-                Example:
-                    ipv4_src=0x11
-                    ipv4_src=0x11&vlan_id=0x01
-                    ipv4_src=0x12&vlan_id=0x01";
-            }
-
-            container counters {
-              description
-                "Counters that correspond to the enumerated flow metrics associated
-                with a name-value-response as identifier of that enumerated flow.";
-
-              uses flow-counters;
-            }
+            uses flow-counters;
           }
         }
       }

--- a/models/flow/open-traffic-generator-flow.yang
+++ b/models/flow/open-traffic-generator-flow.yang
@@ -71,7 +71,7 @@ module open-traffic-generator-flow {
           }
         }
 
-        uses tag-metrics;
+        uses tagged-metrics;
       }
     }
   }
@@ -160,27 +160,27 @@ module open-traffic-generator-flow {
     }
   }
 
-  grouping tag-metrics {
+  grouping tagged-metrics {
     description
-      "Structural grouping for tag-metrics information";
+      "Structural grouping for tagged-metrics information";
 
-    container tag-metrics {
+    container tagged-metrics {
       description
         "Container of tag metric information.";
 
-      list tag-metric {
-        key "name-value";
+      list tagged-metric {
+        key "name-value-pairs";
 
         description
           "A list of enumerated metric, based on all metric tags present in the configuration.
-          Each enumerated metric is identified by a name-value";
+          Each enumerated metric is identified by a name-value-pairs";
 
-        leaf name-value {
+        leaf name-value-pairs {
           type leafref {
-            path "../state/name-value";
+            path "../state/name-value-pairs";
           }
           description
-            "Reference to a name-value, acting as
+            "Reference to a name-value-pairs, acting as
             a key of the tag-metric list.";
         }
 
@@ -188,7 +188,7 @@ module open-traffic-generator-flow {
           description
             "Operational state of the individual tag-metric.";
 
-          leaf name-value {
+          leaf name-value-pairs {
             type string;
             description
               "Encoded string represents one or more metric tag names and corresponding tag value,
@@ -317,7 +317,7 @@ module open-traffic-generator-flow {
           container counters {
             description
               "Counters that correspond to the enumerated flow metrics associated
-              with a name-value as identifier of that enumerated flow.";
+              with a name-value-pairs as identifier of that enumerated flow.";
 
             uses flow-counters;
           }

--- a/models/flow/open-traffic-generator-flow.yang
+++ b/models/flow/open-traffic-generator-flow.yang
@@ -166,16 +166,14 @@ module open-traffic-generator-flow {
 
     container tag-metrics {
       description
-        "A list of tag-metrics which represent one or more metric tags (request)
-            to enumerate flow metrics and associated enumerated flow metrics (response).
-            Each tag-metrics is identified by a name-value-request.";
+        "Container of tag metric information.";
 
       list tag-metric {
         key "name-value";
 
         description
-          "A list of enumerated flow metric, based on metric tags in the configuration.
-          Each enumerated flow metric is identified by a name-value";
+          "A list of enumerated metric, based on all metric tags present in the configuration.
+          Each enumerated metric is identified by a name-value";
 
         leaf name-value {
           type leafref {
@@ -188,7 +186,7 @@ module open-traffic-generator-flow {
 
         container state {
           description
-            "Operational state of the individual metric.";
+            "Operational state of the individual tag-metric.";
 
           leaf name-value {
             type string;
@@ -200,7 +198,12 @@ module open-traffic-generator-flow {
               Example:
                   ipv4_src=0x11
                   ipv4_src=0x11&vlan_id=0x01
-                  ipv4_src=0x12&vlan_id=0x01";
+                  ipv4_src=0x12&vlan_id=0x01
+                  ipv4_dst=2.2.2.2&mpls_label=1000
+              Note:
+                  If metric tag is set match a packet field partially, value format will be in hex (e.g. last 8 bit of IPv4 Src field)
+                  However if metric tag is enabled for the entire packet field, value will be in the native format of the field
+                  (e.g. value format in IPv4 if metric tag set for entire IPv4 Dst field)";
           }
 
           container counters {

--- a/models/flow/open-traffic-generator-flow.yang
+++ b/models/flow/open-traffic-generator-flow.yang
@@ -191,19 +191,128 @@ module open-traffic-generator-flow {
           leaf name-value {
             type string;
             description
-              "Encoded string represents one or more metric tag name and corresponding tag value,
+              "Encoded string represents one or more metric tag names and corresponding tag value,
               to identify each enumerated flow.
               Encoding format:
                   tag_name=value&tag_name=value
+              In encoded string, metric tags MUST be arranged in alphabetical order of the tag name. And tag value(s) in lowercase only.
               Example:
-                  ipv4_src=0x11
-                  ipv4_src=0x11&vlan_id=0x01
-                  ipv4_src=0x12&vlan_id=0x01
-                  ipv4_dst=2.2.2.2&mpls_label=1000
+                ipv4_src=0x11
+                ipv4_src=0x11&vlan_id=0x12ab
+                ipv4_dst=2.2.2.2&mpls_label=1000
+              Incorrect encoding example:
+                vlan_id=0x12AB                  // value in uppercase
+                vlan_id=0x12ab&ipv4_src=0x11    // tag name not in alphabetical order
               Note:
-                  If metric tag is set match a packet field partially, value format will be in hex (e.g. last 8 bit of IPv4 Src field)
-                  However if metric tag is enabled for the entire packet field, value will be in the native format of the field
-                  (e.g. value format in IPv4 if metric tag set for entire IPv4 Dst field)";
+                  If the metric tag is set to match a packet field partially, the value format will be in hex
+                  (e.g. tag set on last 8 bits of the IPv4 Src field)
+                  However, if the metric tag is enabled for the entire packet field, the value will be in the native format of the field
+                  (e.g. value format in IPv4 address if the metric tag is set for the entire IPv4 Dst field)";
+          }
+
+          list tags {
+            description
+              "A list of metric tag names and associated tag values, in a structured manner to identify each enumerated flow.
+              The order of the metric tags in the list is by alphabetical order of the tag name";
+
+            leaf tag-name {
+              type string;
+              description
+                "The name of the metric tag corresponding to this enumerated flow.";
+            }
+
+            container tag-value {
+              description
+                "The value of the metric tag corresponding to this enumerated flow.
+                Value format is based on the metric tag configuration of the Flow";
+
+              leaf value-type {
+                type enumeration {
+                  enum STRING {
+                    description
+                      "Indicates Tag value in String format. Only 'value-as-string' contains the value";
+                  }
+                  enum HEX {
+                    description
+                      "Indicates Tag value in Hex String format. Only 'value-as-hex' contains the value";
+                  }
+                  enum BOOL {
+                    description
+                      "Indicates Tag value in Boolean format. Only 'value-as-bool' contains the value";
+                  }
+                  enum COUNTER64 {
+                    description
+                      "Indicates Tag value in counter64 (64-bit unsigned number) format. Only 'value-as-counter64' contains the value";
+                  }
+                  enum FLOAT32 {
+                    description
+                      "Indicates Tag value in 32-bit floating point number format. Only 'value-as-float32' contains the value";
+                  }
+                  enum IPV4 {
+                    description
+                      "Indicates Tag value in IPv4 address format. Only 'value-as-ipv4' contains the value";
+                  }
+                  enum IPV6 {
+                    description
+                      "Indicates Tag value in IPv6 address format. Only 'value-as-ipv6' contains the value";
+                  }
+                  enum MAC {
+                    description
+                      "Indicates Tag value in MAC address format. Only 'value-as-mac' contains the value";
+                  }
+                }
+                description
+                  "Indicates the format of the tag value. Based on the format, only one 'value-as-*' field will be populated.";
+              }
+
+              leaf value-as-string {
+                type string;
+                description
+                  "Contains Tag Value in String format.";
+              }
+
+              leaf value-as-hex {
+                type otg-types:hex-string;
+                description
+                  "Contains Tag Value in Hex String format.";
+              }
+
+              leaf value-as-bool {
+                type boolean;
+                description
+                  "Contains Tag Value in Boolean format.";
+              }
+
+              leaf value-as-counter64 {
+                type otg-types:counter64;
+                description
+                  "Contains Tag Value in Counter64 (64-bit unsigned number) format.";
+              }
+
+              leaf value-as-float32 {
+                type otg-types:ieeefloat32;
+                description
+                  "Contains Tag Value in 32-bit floating point number format.";
+              }
+
+              leaf value-as-ipv4 {
+                type otg-types:ipv4-address;
+                description
+                  "Contains Tag Value in IPv4 address format.";
+              }
+
+              leaf value-as-ipv6 {
+                type otg-types:ipv6-address;
+                description
+                  "Contains Tag Value in IPv6 address format.";
+              }
+
+              leaf value-as-mac {
+                type otg-types:mac-address;
+                description
+                  "Contains Tag Value in MAC address format.";
+              }
+            }
           }
 
           container counters {


### PR DESCRIPTION
Proposed model for flows, with a new tree node `tag-metrics` for disaggregated stats:
This model is prepared based on review comments on PR https://github.com/open-traffic-generator/models-yang/pull/24 from [Greg Dennis](https://github.com/greg-dennis) 
```
module: open-traffic-generator-flow
  +--rw flows
     +--ro flow* [name]
        +--ro name           -> ../state/name
        +--ro state
        |  +--ro name?             string
        |  +--ro transmit?         boolean
        |  +--ro loss-pct?         otg-types:ieeefloat32
        |  +--ro out-frame-rate?   otg-types:ieeefloat32
        |  +--ro in-frame-rate?    otg-types:ieeefloat32
        |  +--ro out-rate?         otg-types:ieeefloat32
        |  +--ro in-rate?          otg-types:ieeefloat32
        |  +--ro counters
        |     +--ro in-octets?    otg-types:counter64
        |     +--ro in-pkts?      otg-types:counter64
        |     +--ro out-octets?   otg-types:counter64
        |     +--ro out-pkts?     otg-types:counter64
        +--ro tag-metrics
           +--ro tag-metric* [name-value]
              +--ro name-value    -> ../state/name-value
              +--ro state
                 +--ro name-value?   string
                 +--ro tags* []
                 |  +--ro tag-name?    string
                 |  +--ro tag-value
                 |     +--ro value-type?           enumeration
                 |     +--ro value-as-string?      string
                 |     +--ro value-as-hex?         otg-types:hex-string
                 |     +--ro value-as-bool?        boolean
                 |     +--ro value-as-counter64?   otg-types:counter64
                 |     +--ro value-as-float32?     otg-types:ieeefloat32
                 |     +--ro value-as-ipv4?        otg-types:ipv4-address
                 |     +--ro value-as-ipv6?        otg-types:ipv6-address
                 |     +--ro value-as-mac?         otg-types:mac-address
                 +--ro counters
                    +--ro in-octets?    otg-types:counter64
                    +--ro in-pkts?      otg-types:counter64
                    +--ro out-octets?   otg-types:counter64
                    +--ro out-pkts?     otg-types:counter64
```

If `metric_tags` are not present in the flow configuration (i.e. the user has not enabled tracking), gNMI response will contain empty value for `tag-metrics` node.


Assuming the following packet distribution for flow `F1`, some example gNMI query and results are described below:
![image](https://user-images.githubusercontent.com/79712606/230909845-5bfade8d-7e72-40f8-9cb9-cf62b157babe.png)
Here metric-tags are configured only for `VLAN ID` & `Src IP`, whereas `Dst IP` is shown to represent the packet and corresponding stats.

### 1. Query per-flow stats (including aggregated + disaggregated stats):
gNMI query path: “/flows/flow[name=F1]/”
gNMI response:
```
"updates": [
  {
	"Path": "flows/flow[name=f1]",
	"values": {
	  "flows/flow": {
		"open-traffic-generator-flow:name": "f1",
		"open-traffic-generator-flow:state": {                     // Contains the aggregated per-flow stats
		  "counters": {
			"in-octets": "2400",
			"in-pkts": "300",
			"out-octets": "2400",
			"out-pkts": "300"
		  },
		  "in-frame-rate": "QKAAAA==",
		  "name": "f1",
		  "out-frame-rate": "QCAAAA==",
		  "transmit": true
		},
		"open-traffic-generator-flow:tag-metrics": {              // Contains the disaggregated per-flow stats
		  "tag-metric": [
			{
			  "name-value": "ip=0x1&vlan=0x64",
			  "state": {
				"counters": {
				  "in-octets": "800",
				  "in-pkts": "100"
				},
				"name-value": "ip=0x1&vlan=0x64",
				"tags": [
				  {
					"tag-name": "ip",
					"tag-value": {
					  "value-as-hex": "0x1",
					  "value-type": "HEX"
					}
				  },
				  {
					"tag-name": "vlan",
					"tag-value": {
					  "value-as-hex": "0x64",
					  "value-type": "HEX"
					}
				  }
				]
			  }
			},
			{
			  "name-value": "ip=0x1&vlan=0xce",
			  "state": {
				"counters": {
				  "in-octets": "160",
				  "in-pkts": "20"
				},
				"name-value": "ip=0x1&vlan=0xce"
				"tags": [
				  {
					"tag-name": "ip",
					"tag-value": {
					  "value-as-hex": "0x1",
					  "value-type": "HEX"
					}
				  },
				  {
					"tag-name": "vlan",
					"tag-value": {
					  "value-as-hex": "0xce",
					  "value-type": "HEX"
					}
				  }
				]
			  }
			},
			{
			  "name-value": "ip=0x2&vlan=0x64",
			  "state": {
				"counters": {
				  "in-octets": "1200",
				  "in-pkts": "150"
				},
				"name-value": "ip=0x2&vlan=0x64"
				"tags": [
				  {
					"tag-name": "ip",
					"tag-value": {
					  "value-as-hex": "0x2",
					  "value-type": "HEX"
					}
				  },
				  {
					"tag-name": "vlan",
					"tag-value": {
					  "value-as-hex": "0x64",
					  "value-type": "HEX"
					}
				  }
				]
			  }
			},
			{
			  "name-value": "ip=0x2&vlan=0xce",
			  "state": {
				"counters": {
				  "in-octets": "240",
				  "in-pkts": "30"
				},
				"name-value": "ip=0x2&vlan=0xce"
				"tags": [
				  {
					"tag-name": "ip",
					"tag-value": {
					  "value-as-hex": "0x2",
					  "value-type": "HEX"
					}
				  },
				  {
					"tag-name": "vlan",
					"tag-value": {
					  "value-as-hex": "0xce",
					  "value-type": "HEX"
					}
				  }
				]
			  }
			}
		  ]
		}
	  }
	}
  }
]

```

**Note:** Assumption, Metric Tag for Src IP is configured only for the last 8 bits. Hence IP Src address is matched for the last 8 bits appearing in the result. 

### 2. Query only the disaggregated stats (based on all metric tags present in the configuration):
gNMI query path: “/flows/flow[name=F1]/tag-metrics”
gNMI response:

```
"updates": [
  {
	"Path": "flows/flow[name=f1]/tag-metrics/tag-metric[name-value=ip=0x1&vlan=0xce]",
	"values": {
	  "flows/flow/tag-metrics/tag-metric": {
		"open-traffic-generator-flow:name-value": "ip=0x1&vlan=0xce",
		"open-traffic-generator-flow:state": {
		  "counters": {
			"in-octets": "160",
			"in-pkts": "20"
		  },
		  "name-value": "ip=0x1&vlan=0xce"
		  "tags": [
		    {
			  "tag-name": "ip",
			  "tag-value": {
			    "value-as-hex": "0x1",
			    "value-type": "HEX"
			  }
		    },
		    {
			  "tag-name": "vlan",
			  "tag-value": {
			    "value-as-hex": "0xce",
			    "value-type": "HEX"
			  }
		    }
		  ]
		}
	  }
	}
  },
  {
	"Path": "flows/flow[name=f1]/tag-metrics/tag-metric[name-value=ip=0x2&vlan=0xce]",
	"values": {
	  "flows/flow/tag-metrics/tag-metric": {
		"open-traffic-generator-flow:name-value": "ip=0x2&vlan=0xce",
		"open-traffic-generator-flow:state": {
		  "counters": {
			"in-octets": "240",
			"in-pkts": "30"
		  },
		  "name-value": "ip=0x2&vlan=0xce"
		  "tags": [
		    {
			  "tag-name": "ip",
			  "tag-value": {
			    "value-as-hex": "0x2",
			    "value-type": "HEX"
			  }
		    },
		    {
			  "tag-name": "vlan",
			  "tag-value": {
			    "value-as-hex": "0xce",
			    "value-type": "HEX"
			  }
		    }
		  ]
		}
	  }
	}
  },
  {
	"Path": "flows/flow[name=f1]/tag-metrics/tag-metric[name-value=ip=0x1&vlan=0x64]",
	"values": {
	  "flows/flow/tag-metrics/tag-metric": {
		"open-traffic-generator-flow:name-value": "ip=0x1&vlan=0x64",
		"open-traffic-generator-flow:state": {
		  "counters": {
			"in-octets": "800",
			"in-pkts": "100"
		  },
		  "name-value": "ip=0x1&vlan=0x64"
		  "tags": [
		    {
			  "tag-name": "ip",
			  "tag-value": {
			    "value-as-hex": "0x1",
			    "value-type": "HEX"
			  }
		    },
		    {
			  "tag-name": "vlan",
			  "tag-value": {
			    "value-as-hex": "0x64",
			    "value-type": "HEX"
			  }
		    }
		  ]
		}
	  }
	}
  },
  {
	"Path": "flows/flow[name=f1]/tag-metrics/tag-metric[name-value=ip=0x2&vlan=0x64]",
	"values": {
	  "flows/flow/tag-metrics/tag-metric": {
		"open-traffic-generator-flow:name-value": "ip=0x2&vlan=0x64",
		"open-traffic-generator-flow:state": {
		  "counters": {
			"in-octets": "1200",
			"in-pkts": "150"
		  },
		  "name-value": "ip=0x2&vlan=0x64"
		  "tags": [
		    {
			  "tag-name": "ip",
			  "tag-value": {
			    "value-as-hex": "0x2",
			    "value-type": "HEX"
			  }
		    },
		    {
			  "tag-name": "vlan",
			  "tag-value": {
			    "value-as-hex": "0x64",
			    "value-type": "HEX"
			  }
		    }
		  ]
		}
	  }
	}
  }
]
            
```

### 3. Query disaggregated stats for VLAN ID = 100 & Src IP = 10.10.10.1 (multi-field tracking with filtering):
gNMI query path: "flows/flow[name=f1]/tag-metrics/tag-metric[name-value='ip=0x1&vlan=0x64']"
gNMI response:
```
"updates": [
  {
	"Path": "flows/flow[name=f1]/tag-metrics/tag-metric[name-value=ip=0x1&vlan=0x64]",
	"values": {
	  "flows/flow/tag-metrics/tag-metric": {
		"open-traffic-generator-flow:name-value": "ip=0x1&vlan=0x64",
		"open-traffic-generator-flow:state": {
		  "counters": {
			"in-octets": "800",
			"in-pkts": "100"
		  },
		  "name-value": "ip=0x1&vlan=0xce"
		  "tags": [
		    {
			  "tag-name": "ip",
			  "tag-value": {
			    "value-as-hex": "0x1",
			    "value-type": "HEX"
			  }
		    },
		    {
			  "tag-name": "vlan",
			  "tag-value": {
			    "value-as-hex": "0xce",
			    "value-type": "HEX"
			  }
		    }
		  ]

		}
	  }
	}
  }
]

```

### 4. Query only the aggregated stats:
**Option A:** Query only for the "state" 
gNMI query path: "flows/flow[name=f1]/state]"
gNMI response:
```
"updates": [
  {
	"Path": "flows/flow[name=f1]/state/counters",
	"values": {
	  "flows/flow/state/counters": {
		"open-traffic-generator-flow:in-octets": "2000",
		"open-traffic-generator-flow:in-pkts": "200",
		"open-traffic-generator-flow:out-octets": "1000",
		"open-traffic-generator-flow:out-pkts": "59"
	  }
	}
  },
  {
	"Path": "flows/flow[name=f1]/state/in-frame-rate",
	"values": {
	  "flows/flow/state/in-frame-rate": "QKAAAA=="
	}
  },
  {
	"Path": "flows/flow[name=f1]/state/name",
	"values": {
	  "flows/flow/state/name": "f1"
	}
  },
  {
	"Path": "flows/flow[name=f1]/state/out-frame-rate",
	"values": {
	  "flows/flow/state/out-frame-rate": "QCAAAA=="
	}
  },
  {
	"Path": "flows/flow[name=f1]/state/transmit",
	"values": {
	  "flows/flow/state/transmit": true
	}
  }
]


```

**Option B:** Remove 'tag_metrics' from the configuration and then do a fresh query: 
gNMI query path: "flows/flow[name=f1]/]"
gNMI response:
```
"updates": [
  {
	"Path": "flows/flow[name=f1]",
	"values": {
	  "flows/flow": {
		"open-traffic-generator-flow:name": "f1",
		"open-traffic-generator-flow:state": {
		  "counters": {
			"in-octets": "2000",
			"in-pkts": "200",
			"out-octets": "1000",
			"out-pkts": "81"
		  },
		  "in-frame-rate": "QKAAAA==",
		  "name": "f1",
		  "out-frame-rate": "QCAAAA==",
		  "transmit": true
		}
	  }
	}
  }
]

```