### PR TITLE
adding git dhcpv4 client server yang model

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -51,6 +51,8 @@ jobs:
           git add -f artifacts/open-traffic-generator-lacp.txt
           git add -f artifacts/open-traffic-generator-rsvp.txt
           git add -f artifacts/open-traffic-generator-lldp.txt
+          git add -f open-traffic-generator-dhcpv4client.txt
+          git add -f open-traffic-generator-dhcpv4server.txt
           if git status --porcelain | grep .
             then
               git commit -m "Update auto generated content"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -61,4 +61,3 @@ jobs:
             else
               echo "No changed auto generated content"
           fi
-git

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -51,8 +51,8 @@ jobs:
           git add -f artifacts/open-traffic-generator-lacp.txt
           git add -f artifacts/open-traffic-generator-rsvp.txt
           git add -f artifacts/open-traffic-generator-lldp.txt
-          git add -f open-traffic-generator-dhcpv4client.txt
-          git add -f open-traffic-generator-dhcpv4server.txt
+          git add -f artifacts/open-traffic-generator-dhcpv4client.txt
+          git add -f artifacts/open-traffic-generator-dhcpv4server.txt
           if git status --porcelain | grep .
             then
               git commit -m "Update auto generated content"

--- a/artifacts/open-traffic-generator-dhcpv4client.txt
+++ b/artifacts/open-traffic-generator-dhcpv4client.txt
@@ -1,0 +1,21 @@
+module: open-traffic-generator-dhcpv4client
+  +--rw dhcpv4-clients
+     +--ro dhcpv4-client* [name]
+        +--ro name     -> ../state/name
+        +--ro state
+           +--ro name?       string
+           +--ro counters
+           |  +--ro discovers-sent?    otg-types:counter64
+           |  +--ro offers-received?   otg-types:counter64
+           |  +--ro requests-sent?     otg-types:counter64
+           |  +--ro acks-received?     otg-types:counter64
+           |  +--ro nacks-received?    otg-types:counter64
+           |  +--ro releases-sent?     otg-types:counter64
+           |  +--ro declines-sent?     otg-types:counter64
+           +--ro address
+              +--ro address?           otg-types:ipv4-address
+              +--ro prefix-length?     uint32
+              +--ro gateway_address?   otg-types:ipv4-address
+              +--ro lease_time?        uint32
+              +--ro renew_time?        uint32
+              +--ro rebind_time?       uint32

--- a/artifacts/open-traffic-generator-dhcpv4client.txt
+++ b/artifacts/open-traffic-generator-dhcpv4client.txt
@@ -3,7 +3,7 @@ module: open-traffic-generator-dhcpv4client
      +--ro dhcpv4-client* [name]
         +--ro name     -> ../state/name
         +--ro state
-           +--ro name?       string
+           +--ro name?        string
            +--ro counters
            |  +--ro discovers-sent?    otg-types:counter64
            |  +--ro offers-received?   otg-types:counter64
@@ -12,7 +12,7 @@ module: open-traffic-generator-dhcpv4client
            |  +--ro nacks-received?    otg-types:counter64
            |  +--ro releases-sent?     otg-types:counter64
            |  +--ro declines-sent?     otg-types:counter64
-           +--ro address
+           +--ro interface
               +--ro address?           otg-types:ipv4-address
               +--ro prefix-length?     uint32
               +--ro gateway_address?   otg-types:ipv4-address

--- a/artifacts/open-traffic-generator-dhcpv4server.txt
+++ b/artifacts/open-traffic-generator-dhcpv4server.txt
@@ -1,6 +1,6 @@
 module: open-traffic-generator-dhcpv4server
   +--rw dhcpv4-servers
-     +--ro servers* [name]
+     +--ro dhcpv4-server* [name]
         +--ro name     -> ../state/name
         +--ro state
            +--ro name?       string

--- a/artifacts/open-traffic-generator-dhcpv4server.txt
+++ b/artifacts/open-traffic-generator-dhcpv4server.txt
@@ -1,0 +1,26 @@
+module: open-traffic-generator-dhcpv4server
+  +--rw dhcpv4-servers
+     +--ro servers* [name]
+        +--ro name     -> ../state/name
+        +--ro state
+           +--ro name?       string
+           +--ro counters
+           |  +--ro discovers-received?   otg-types:counter64
+           |  +--ro offers-sent?          otg-types:counter64
+           |  +--ro requests-received?    otg-types:counter64
+           |  +--ro acks-sent?            otg-types:counter64
+           |  +--ro nacks-sent?           otg-types:counter64
+           |  +--ro releases-received?    otg-types:counter64
+           |  +--ro declines-received?    otg-types:counter64
+           +--ro leases
+              +--ro leases-states
+                 +--ro leases* [address]
+                    +--ro address    -> ../state/address
+                    +--ro state
+                       +--ro address?          otg-types:ipv4-address
+                       +--ro valid-time?       uint32
+                       +--ro preferred_time?   uint32
+                       +--ro renew_time?       uint32
+                       +--ro rebind_time?      uint32
+                       +--ro client-id?        string
+                       +--ro circuit-id?       string

--- a/artifacts/open-traffic-generator-dhcpv4server.txt
+++ b/artifacts/open-traffic-generator-dhcpv4server.txt
@@ -24,3 +24,4 @@ module: open-traffic-generator-dhcpv4server
                        +--ro rebind_time?      uint32
                        +--ro client-id?        string
                        +--ro circuit-id?       string
+                       +--ro remote-id?        string

--- a/artifacts/open-traffic-generator-dhcpv4server.txt
+++ b/artifacts/open-traffic-generator-dhcpv4server.txt
@@ -14,7 +14,7 @@ module: open-traffic-generator-dhcpv4server
            |  +--ro declines-received?    otg-types:counter64
            +--ro leases
               +--ro leases-states
-                 +--ro leases* [address]
+                 +--ro hosts* [address]
                     +--ro address    -> ../state/address
                     +--ro state
                        +--ro address?          otg-types:ipv4-address

--- a/models/dhcp/v4client/open-traffic-generator-dhcpv4client.yang
+++ b/models/dhcp/v4client/open-traffic-generator-dhcpv4client.yang
@@ -1,0 +1,182 @@
+module open-traffic-generator-dhcpv4client {
+  yang-version "1";
+
+  namespace "http://gitub.com/open-traffic-generator/models-yang/models/dhcp/vclient";
+  prefix "otg-dhcpv4client";
+
+  import open-traffic-generator-types {
+    prefix "otg-types";
+  }
+
+  organization
+    "OpenTrafficGenerator working group";
+
+  contact
+    "OpenTrafficGenerator working group
+     opentrafficgenerator@googlegroups.com";
+
+  description
+    "This module defines telemetry that relOTGs to dhcpv4client sessions that
+    are controlled by an open traffic generator (OTG) whose definition
+    is outside of the context of this module.";
+
+  revision 2022-01-21 {
+    description "Initial revision.";
+    reference "0.1.0";
+  }
+
+  grouping dhcpv4clients-top {
+    description
+      "Top-level structural grouping for DHCPv4 Client telemetry
+      entries.";
+
+    container dhcpv4-clients {
+      description
+        "DHCPv4 Clients telemetry collected by the OTG device.";
+
+      list dhcpv4-client {
+        key "name";
+
+        config false;
+
+        description
+          "Each DHCPv4 Client is identified by an arbitrary string
+          identifier.";
+
+        leaf name {
+          type leafref {
+            path "../state/name";
+          }
+          description
+            "Reference to the DHCPv4 Client's name, acting as a key of
+            the DHCPv4 Client list.";
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state of an individual DHCPv4 Client.";
+          uses dhcpv4client-state;
+        }
+      }
+    }
+  }
+
+  grouping dhcpv4client-state {
+    description
+      "Operational state of an individual DHCPv4 Client.";
+
+    leaf name {
+      type string;
+      description
+        "An arbitary name of the DHCPv4 Client determined by the OTG
+        configuration.";
+    }
+
+    container counters {
+      description
+        "Counters of an indivdual DHCPv4 session.";
+
+      uses dhcp4client-counters;
+    }
+    container address {
+      description
+        "Information about address learned by an indivdual DHCPv4 session.";
+
+      uses dhcp4client-address;
+    }
+  }
+
+  grouping dhcp4client-counters {
+    description
+      "Counters of the DHCPv4 Client.";
+
+    leaf sessions-up {
+      type otg-types:counter64;
+      description
+        "The total number of sessions that are fully up.";
+    }
+    leaf sessions-down {
+      type otg-types:counter64;
+      description
+        "The total number of sessions that are down.";
+    }
+    leaf discovers-sent {
+      type otg-types:counter64;
+      description
+        "Number of DHCPDISCOVER messages sent.";
+    }
+    leaf offers-received {
+      type otg-types:counter64;
+      description
+        "Number of DHCPOFFER messages received.";
+    }
+    leaf requests-sent {
+      type otg-types:counter64;
+      description
+        "Number of DHCPREQUEST messages sent.";
+    }
+    leaf acks-received {
+      type otg-types:counter64;
+      description
+        "Number of DHCPACKS messages received.";
+    }
+    leaf nacks-received {
+      type otg-types:counter64;
+      description
+        "Number of NACKS messages received.";
+    }
+    leaf releases-sent {
+      type otg-types:counter64;
+      description
+        "Number of RELEASE messages sent.";
+    }
+    leaf declines-sent {
+      type otg-types:counter64;
+      description
+        "Number of RELEASE messages sent.";
+    }
+  }
+
+  grouping dhcp4client-address {
+    description
+      "This grouping defines learning of IPv4 address information.";
+    reference
+      "1. https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dhcp_support_pr/artifacts/openapi.yaml&nocors";
+
+    leaf address {
+      type otg-types:ipv4-address;
+      description
+        "The IPv4 address associated with this DHCP Client session.";
+    }
+
+    leaf prefix-length {
+      type uint32;
+      description
+        "The length of the prefix";
+    }
+
+    leaf gateway_address {
+      type otg-types:ipv4-address;
+      description
+        "The Gateway address associated with this DHCP Client session.";
+    }
+    leaf lease_time {
+      type uint32;
+      description
+        "The length of the prefix.";
+    }
+    leaf renew_time {
+      type uint32;
+      description
+        "Time in seconds until the DHCPv4 client starts renewing the lease.";
+    }
+    leaf rebind_time {
+      type uint32;
+      description
+        "Time in seconds until the DHCPv4 client starts rebinding.";
+    }
+  }
+
+  uses dhcpv4clients-top;
+}

--- a/models/dhcp/v4client/open-traffic-generator-dhcpv4client.yang
+++ b/models/dhcp/v4client/open-traffic-generator-dhcpv4client.yang
@@ -159,7 +159,7 @@ module open-traffic-generator-dhcpv4client {
     leaf gateway_address {
       type otg-types:ipv4-address;
       description
-        "The Gateway address associated with this DHCP Client session.";
+        "The Gateway address associated with the DHCP Client session.";
     }
     leaf lease_time {
       type uint32;

--- a/models/dhcp/v4client/open-traffic-generator-dhcpv4client.yang
+++ b/models/dhcp/v4client/open-traffic-generator-dhcpv4client.yang
@@ -29,6 +29,8 @@ module open-traffic-generator-dhcpv4client {
     description
       "Top-level structural grouping for DHCPv4 Client telemetry
       entries.";
+    reference
+      "1. https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dhcp_support_support/artifacts/openapi.yaml&nocors";
 
     container dhcpv4-clients {
       description
@@ -130,9 +132,6 @@ module open-traffic-generator-dhcpv4client {
   grouping dhcp4client-address {
     description
       "This grouping defines learning of IPv4 address information.";
-    reference
-      "1. https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dhcp_support_pr/artifacts/openapi.yaml&nocors";
-
     leaf address {
       type otg-types:ipv4-address;
       description

--- a/models/dhcp/v4client/open-traffic-generator-dhcpv4client.yang
+++ b/models/dhcp/v4client/open-traffic-generator-dhcpv4client.yang
@@ -16,11 +16,11 @@ module open-traffic-generator-dhcpv4client {
      opentrafficgenerator@googlegroups.com";
 
   description
-    "This module defines telemetry that relOTGs to dhcpv4client sessions that
+    "This module defines telemetry that relates OTG to dhcpv4client sessions that
     are controlled by an open traffic generator (OTG) whose definition
     is outside of the context of this module.";
 
-  revision 2022-01-21 {
+  revision 2024-04-10 {
     description "Initial revision.";
     reference "0.1.0";
   }
@@ -90,17 +90,6 @@ module open-traffic-generator-dhcpv4client {
   grouping dhcp4client-counters {
     description
       "Counters of the DHCPv4 Client.";
-
-    leaf sessions-up {
-      type otg-types:counter64;
-      description
-        "The total number of sessions that are fully up.";
-    }
-    leaf sessions-down {
-      type otg-types:counter64;
-      description
-        "The total number of sessions that are down.";
-    }
     leaf discovers-sent {
       type otg-types:counter64;
       description
@@ -124,17 +113,17 @@ module open-traffic-generator-dhcpv4client {
     leaf nacks-received {
       type otg-types:counter64;
       description
-        "Number of NACKS messages received.";
+        "Number of DHCPNACKS messages received.";
     }
     leaf releases-sent {
       type otg-types:counter64;
       description
-        "Number of RELEASE messages sent.";
+        "Number of DHCPRELEASE messages sent.";
     }
     leaf declines-sent {
       type otg-types:counter64;
       description
-        "Number of RELEASE messages sent.";
+        "Number of DHCPDECLINE messages sent.";
     }
   }
 
@@ -164,7 +153,7 @@ module open-traffic-generator-dhcpv4client {
     leaf lease_time {
       type uint32;
       description
-        "The length of the prefix.";
+        "The duration of the IP address lease, in seconds.";
     }
     leaf renew_time {
       type uint32;

--- a/models/dhcp/v4client/open-traffic-generator-dhcpv4client.yang
+++ b/models/dhcp/v4client/open-traffic-generator-dhcpv4client.yang
@@ -81,11 +81,11 @@ module open-traffic-generator-dhcpv4client {
 
       uses dhcp4client-counters;
     }
-    container address {
+    container interface {
       description
         "Information about address learned by an indivdual DHCPv4 session.";
 
-      uses dhcp4client-address;
+      uses dhcp4-interface;
     }
   }
 
@@ -129,7 +129,7 @@ module open-traffic-generator-dhcpv4client {
     }
   }
 
-  grouping dhcp4client-address {
+  grouping dhcp4-interface {
     description
       "This grouping defines learning of IPv4 address information.";
     leaf address {

--- a/models/dhcp/v4server/open-traffic-generator-dhcpv4server.yang
+++ b/models/dhcp/v4server/open-traffic-generator-dhcpv4server.yang
@@ -82,7 +82,7 @@ module open-traffic-generator-dhcpv4server {
         "This sub-module describes a YANG model for
          the Host allocated status of a DHCPv4 Server";
 
-      uses dhcpv4server-leases-states;
+      uses dhcpv4-leases-states;
     }
   }
 
@@ -126,22 +126,22 @@ module open-traffic-generator-dhcpv4server {
     }
   }
 
-  grouping dhcpv4server-leases-states {
+  grouping dhcpv4-leases-states {
     description
       "This grouping defines DHCPv4 Server Leases States information.";
     container leases-states {
       description
         "Container of DHCPv4 Server Leases States information.";
-      list leases {
+      list hosts {
         key "address";
           description
-            "The IPv4 address associated with this lease";
+            "The IPv4 address associated with this lease for the Host";
           leaf address {
             type leafref {
               path "../state/address";
             }
             description
-              "A reference to address that has been leased.";
+              "A reference to address that has been leased for the Host.";
           }
         container state {
           description

--- a/models/dhcp/v4server/open-traffic-generator-dhcpv4server.yang
+++ b/models/dhcp/v4server/open-traffic-generator-dhcpv4server.yang
@@ -1,0 +1,184 @@
+module open-traffic-generator-dhcpv4server {
+  yang-version "1";
+
+  namespace "http://gitub.com/open-traffic-generator/models-yang/models/dhcp/v4server";
+  prefix "otg-dhcpv4server";
+
+  import open-traffic-generator-types {
+    prefix "otg-types";
+  }
+
+  organization
+    "OpenTrafficGenerator working group";
+
+  contact
+    "OpenTrafficGenerator working group
+     opentrafficgenerator@googlegroups.com";
+
+  description
+    "This module defines telemetry that relOTGs to dhcpv4Server that
+    are controlled by an open traffic generator (OTG) whose definition
+    is outside of the context of this module.";
+
+  revision 2022-01-21 {
+    description "Initial revision.";
+    reference "0.1.0";
+  }
+
+  grouping dhcpv4servers-top {
+    description
+      "Top-level structural grouping for DHCPv4 Server telemetry
+      entries.";
+
+    container dhcpv4-servers {
+      description
+        "DHCPv4 Servers telemetry collected by the OTG device.";
+
+      list dhcpv4-server {
+        key "name";
+        config false;
+        description
+          "Each DHCPv4 Server is identified by an arbitrary string
+          identifier.";
+        leaf name {
+          type leafref {
+            path "../state/name";
+          }
+          description
+            "Reference to the DHCPv4 Server's name, acting as a key of
+            the DHCPv4 Server list.";
+        }
+        container state {
+          config false;
+          description
+            "Operational state of an individual DHCPv4 Server.";
+          uses dhcpv4server-state;
+        }
+      }
+    }
+  }
+
+  grouping dhcpv4server-state {
+    description
+      "Operational state of an individual DHCPv4 Server.";
+
+    leaf name {
+      type string;
+      description
+        "An arbitary name of the DHCPv4 Server determined by the OTG
+        configuration.";
+    }
+    container counters {
+      description
+        "Counters of an indivdual DHCPv4 session.";
+
+      uses dhcp4server-counters;
+    }
+
+    container leases {
+      description
+        "This sub-module describes a YANG model for
+         the Host allocated status of a DHCPv4 Server";
+
+      uses dhcpv4server-leases;
+    }
+  }
+
+  grouping dhcp4server-counters {
+    description
+      "Counters of the DHCPv4 Server.";
+    leaf discovers-received {
+      type otg-types:counter64;
+      description
+        "Number of DHCPDISCOVER messages received.";
+    }
+    leaf offers-sent {
+      type otg-types:counter64;
+      description
+        "Number of DHCPOFFER messages sent.";
+    }
+    leaf requests-received {
+      type otg-types:counter64;
+      description
+        "Number of DHCPREQUEST messages received.";
+    }
+    leaf acks-sent {
+      type otg-types:counter64;
+      description
+        "Number of DHCPACKS messages sent.";
+    }
+    leaf nacks-sent {
+      type otg-types:counter64;
+      description
+        "Number of NACKS messages sent.";
+    }
+    leaf releases-received {
+      type otg-types:counter64;
+      description
+        "Number of RELEASE messages received.";
+    }
+    leaf declines-received {
+      type otg-types:counter64;
+      description
+        "Number of RELEASE messages received.";
+    }
+  }
+
+  grouping dhcpv4server-leases {
+    description
+      "This grouping defines ISIS LSP state information.";
+    list addresses {
+      key "address";
+        description
+          "The IPv4 address associated with this lease";
+        leaf address {
+          type leafref {
+            path "../state/address";
+          }
+          description
+            "A reference to address that has been leased.";
+        }
+      container state {
+        description
+          "State parameters of the leased address.";
+        leaf address {
+        type otg-types:ipv4-address;
+        description
+          "The IPv4 address associated with this DHCP Client session.";
+        }
+      }
+      leaf valid-time {
+        type uint32;
+        description
+          "The time in seconds, IP address lease will expire";
+      }
+      leaf preferred_time {
+        type uint32;
+        description
+          "The time in seconds, elapsed time since address has been renewed.";
+      }
+      leaf renew_time {
+        type uint32;
+        description
+          "Time in seconds until the DHCPv4 client starts renewing the lease..";
+      }
+      leaf rebind_time {
+        type uint32;
+        description
+          "Time in seconds until the DHCPv4 client starts rebinding.";
+      }
+      leaf client-id {
+        type string;
+        description
+          "The ID of the DHCPv4 client holding this lease.";
+      }
+      leaf circuit-id {
+        type string;
+        description
+          "The Circuit ID option found in the last request message";
+      }
+    }
+  }
+
+  uses dhcpv4servers-top;
+}

--- a/models/dhcp/v4server/open-traffic-generator-dhcpv4server.yang
+++ b/models/dhcp/v4server/open-traffic-generator-dhcpv4server.yang
@@ -181,6 +181,11 @@ module open-traffic-generator-dhcpv4server {
             description
               "The Circuit ID option found in the last request message";
           }
+          leaf remote-id {
+            type string;
+            description
+              "The Remote ID option found in the last request message";
+          }
         }
       }
     }

--- a/models/dhcp/v4server/open-traffic-generator-dhcpv4server.yang
+++ b/models/dhcp/v4server/open-traffic-generator-dhcpv4server.yang
@@ -16,11 +16,11 @@ module open-traffic-generator-dhcpv4server {
      opentrafficgenerator@googlegroups.com";
 
   description
-    "This module defines telemetry that relOTGs to dhcpv4Server that
+    "This module defines telemetry that relates OTG to dhcpv4Server that
     are controlled by an open traffic generator (OTG) whose definition
     is outside of the context of this module.";
 
-  revision 2022-01-21 {
+  revision 2024-04-10 {
     description "Initial revision.";
     reference "0.1.0";
   }
@@ -70,7 +70,7 @@ module open-traffic-generator-dhcpv4server {
     }
     container counters {
       description
-        "Counters of an indivdual DHCPv4 session.";
+        "Counters of an individual DHCPv4 session.";
 
       uses dhcp4server-counters;
     }
@@ -110,17 +110,17 @@ module open-traffic-generator-dhcpv4server {
     leaf nacks-sent {
       type otg-types:counter64;
       description
-        "Number of NACKS messages sent.";
+        "Number of DHCPNACKS messages sent.";
     }
     leaf releases-received {
       type otg-types:counter64;
       description
-        "Number of RELEASE messages received.";
+        "Number of DHCPRELEASES messages received.";
     }
     leaf declines-received {
       type otg-types:counter64;
       description
-        "Number of RELEASE messages received.";
+        "Number of DHCPDECLINES messages received.";
     }
   }
 
@@ -143,7 +143,7 @@ module open-traffic-generator-dhcpv4server {
           }
         container state {
           description
-            "State parameters of the leased address.";
+            "State parameters of the leased addresses.";
           leaf address {
             type otg-types:ipv4-address;
             description
@@ -162,7 +162,7 @@ module open-traffic-generator-dhcpv4server {
           leaf renew_time {
             type uint32;
             description
-              "Time in seconds until the DHCPv4 client starts renewing the lease..";
+              "Time in seconds until the DHCPv4 client starts renewing the lease.";
           }
           leaf rebind_time {
             type uint32;

--- a/models/dhcp/v4server/open-traffic-generator-dhcpv4server.yang
+++ b/models/dhcp/v4server/open-traffic-generator-dhcpv4server.yang
@@ -36,7 +36,7 @@ module open-traffic-generator-dhcpv4server {
       description
         "DHCPv4 Servers telemetry collected by the OTG device.";
 
-      list servers {
+      list dhcpv4-server {
         key "name";
         config false;
         description
@@ -82,7 +82,7 @@ module open-traffic-generator-dhcpv4server {
         "This sub-module describes a YANG model for
          the Host allocated status of a DHCPv4 Server";
 
-      uses dhcpv4-leases-states;
+     uses dhcpv4-leases-states;
     }
   }
 

--- a/models/dhcp/v4server/open-traffic-generator-dhcpv4server.yang
+++ b/models/dhcp/v4server/open-traffic-generator-dhcpv4server.yang
@@ -27,7 +27,7 @@ module open-traffic-generator-dhcpv4server {
 
   grouping dhcpv4servers-top {
     description
-      "Top-level structural grouping for DHCPv4 Server telemetry
+      "Top-level structural grouping for the DHCPv4 Server telemetry
       entries.";
 
     container dhcpv4-servers {

--- a/models/dhcp/v4server/open-traffic-generator-dhcpv4server.yang
+++ b/models/dhcp/v4server/open-traffic-generator-dhcpv4server.yang
@@ -29,6 +29,8 @@ module open-traffic-generator-dhcpv4server {
     description
       "Top-level structural grouping for the DHCPv4 Server telemetry
       entries.";
+    reference
+      "1. https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dhcp_support_support/artifacts/openapi.yaml&nocors";
 
     container dhcpv4-servers {
       description

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyang
+pyang == 2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-setuptools 
+setuptools
 pyang


### PR DESCRIPTION
The DHCPv4 Client and Server yang models for States.
OTG Model for DHCPv4 client and server:  https://github.com/open-traffic-generator/models/pull/371

https://github.com/open-traffic-generator/models-yang/blob/dhcpv4-yang/artifacts/open-traffic-generator-dhcpv4client.txt
https://github.com/open-traffic-generator/models-yang/blob/dhcpv4-yang/artifacts/open-traffic-generator-dhcpv4server.txt

Redoc Reference:
 https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dhcpv4_support_review/artifacts/openapi.yaml&nocors#tag/Configuration

Path for fetching Client Interface information:
// Path from root: "/dhcpv4-clients/dhcpv4-client[name=dhpc4-client1]/state/
// Path from root: "/dhcpv4-clients/dhcpv4-client[name=dhpc4-client1]/state/interface/address"
// Path from root: "/dhcpv4-clients/dhcpv4-client[name=dhpc4-client1]/state/interface/prefix-length"
// Path from root: "/dhcpv4-clients/dhcpv4-client[name=dhpc4-client1]/state/interface/gateway_address"
// Path from root: "/dhcpv4-clients/dhcpv4-client[name=dhpc4-client1]/state/interface/lease_time"
// Path from root: "/dhcpv4-clients/dhcpv4-client[name=dhpc4-client1]/state/interface/renew_time"
