### PR TITLE
Support for get software and sdk version of keng-controller

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   workflow_dispatch:
     paths:
-    - '!artifacts/**'
+      - "!artifacts/**"
 
 jobs:
   build:
@@ -51,6 +51,7 @@ jobs:
           git add -f artifacts/open-traffic-generator-lacp.txt
           git add -f artifacts/open-traffic-generator-rsvp.txt
           git add -f artifacts/open-traffic-generator-lldp.txt
+          git add -f artifacts/open-traffic-generator-platform.txt
           if git status --porcelain | grep .
             then
               git commit -m "Update auto generated content"

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,37 @@ lint: setup ## pyang lint target
 COMMON_ARGS = -path=./models -compress_paths=true -generate_fakeroot -fakeroot_name=device -generate_simple_unions -shorten_enum_leaf_names -typedef_enum_with_defmod -enum_suffix_for_simple_union_enums -trim_enum_openconfig_prefix -include_schema -generate_append -generate_getters -generate_rename -generate_delete -generate_leaf_getters -structs_split_files_count=3 -generate_populate_defaults
 MODELS = `find models -name *.yang`
 generate: lint ## go generation target
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+	go install github.com/openconfig/ygot/generator@latest
+	go install golang.org/x/tools/cmd/goimports@latest
+
+	rm -rf pkg/telemetry && mkdir -p pkg/telemetry/device
+	generator \
+		-generate_structs \
+		-generate_path_structs=false \
+		-prefer_operational_state \
+		-list_builder_key_threshold=4 \
+		-output_dir=pkg/telemetry \
+		-package_name=telemetry \
+		-path_structs_split_files_count=2 \
+		${COMMON_ARGS} \
+		${MODELS}
+
+	generator \
+		-generate_structs=false \
+		-generate_path_structs=true \
+		-prefer_operational_state \
+		-list_builder_key_threshold=4 \
+		-output_dir=pkg/telemetry \
+		-package_name=device \
+		-path_structs_output_file=pkg/telemetry/device/device.go \
+		-split_pathstructs_by_module=true \
+		-schema_struct_path=github.com/open-traffic-generator/ixia-c-gnmi-server/pkg/telemetry \
+		-path_struct_package_suffix="" \
+		-base_import_path=github.com/open-traffic-generator/ixia-c-gnmi-server/pkg/telemetry \
+		-path_structs_split_files_count=2 \
+		$(COMMON_ARGS) \
+		${MODELS}
+
+	find pkg/telemetry -name "*.go" -exec goimports -w {} +
+	find pkg/telemetry -name "*.go" -exec gofmt -w -s {} +

--- a/Makefile
+++ b/Makefile
@@ -20,37 +20,3 @@ lint: setup ## pyang lint target
 COMMON_ARGS = -path=./models -compress_paths=true -generate_fakeroot -fakeroot_name=device -generate_simple_unions -shorten_enum_leaf_names -typedef_enum_with_defmod -enum_suffix_for_simple_union_enums -trim_enum_openconfig_prefix -include_schema -generate_append -generate_getters -generate_rename -generate_delete -generate_leaf_getters -structs_split_files_count=3 -generate_populate_defaults
 MODELS = `find models -name *.yang`
 generate: lint ## go generation target
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-	go install github.com/openconfig/ygot/generator@latest
-	go install golang.org/x/tools/cmd/goimports@latest
-
-	rm -rf pkg/telemetry && mkdir -p pkg/telemetry/device
-	generator \
-		-generate_structs \
-		-generate_path_structs=false \
-		-prefer_operational_state \
-		-list_builder_key_threshold=4 \
-		-output_dir=pkg/telemetry \
-		-package_name=telemetry \
-		-path_structs_split_files_count=2 \
-		${COMMON_ARGS} \
-		${MODELS}
-
-	generator \
-		-generate_structs=false \
-		-generate_path_structs=true \
-		-prefer_operational_state \
-		-list_builder_key_threshold=4 \
-		-output_dir=pkg/telemetry \
-		-package_name=device \
-		-path_structs_output_file=pkg/telemetry/device/device.go \
-		-split_pathstructs_by_module=true \
-		-schema_struct_path=github.com/open-traffic-generator/ixia-c-gnmi-server/pkg/telemetry \
-		-path_struct_package_suffix="" \
-		-base_import_path=github.com/open-traffic-generator/ixia-c-gnmi-server/pkg/telemetry \
-		-path_structs_split_files_count=2 \
-		$(COMMON_ARGS) \
-		${MODELS}
-
-	find pkg/telemetry -name "*.go" -exec goimports -w {} +
-	find pkg/telemetry -name "*.go" -exec gofmt -w -s {} +

--- a/artifacts/open-traffic-generator-platform.txt
+++ b/artifacts/open-traffic-generator-platform.txt
@@ -1,0 +1,7 @@
+module: open-traffic-generator-platform
+  +--rw components
+     +--ro component* [name]
+        +--ro name     -> ../state/name
+        +--ro state
+           +--ro name?         enumeration
+           +--ro sw-version?   string

--- a/artifacts/open-traffic-generator-platform.txt
+++ b/artifacts/open-traffic-generator-platform.txt
@@ -3,5 +3,6 @@ module: open-traffic-generator-platform
      +--ro component* [name]
         +--ro name     -> ../state/name
         +--ro state
-           +--ro name?      enumeration
-           +--ro version?   string
+           +--ro name?               enumeration
+           +--ro software-version?   string
+           +--ro sdk-version?        string

--- a/do.sh
+++ b/do.sh
@@ -3,11 +3,28 @@
 # Avoid warnings for non-interactive apt-get install
 export DEBIAN_FRONTEND=noninteractive
 
+GO_VERSION=1.19
+
+get_go() {
+    echo "\nInstalling Go ...\n"
+    # install golang per https://golang.org/doc/install#tarball
+    curl -kL https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
+        | tar -C /usr/local/ -xzf -
+}
+
+get_go_deps() {
+    echo "\nDowloading go dependencies ...\n"
+    # for generating Go client stubs from openapi.yaml
+    GO111MODULE=on go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+}
+
 install_deps() {
     apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     && apt-get -y install curl git python-is-python3 python3-pip \
-    && python -m pip install --prefer-binary -r requirements.txt 
+    && get_go \
+    && python -m pip install --prefer-binary -r requirements.txt \
+    && get_go_deps 
 }
 
 gen_artifacts() {

--- a/do.sh
+++ b/do.sh
@@ -1,30 +1,13 @@
 #!/bin/sh
 
-GO_VERSION=1.18
-
 # Avoid warnings for non-interactive apt-get install
 export DEBIAN_FRONTEND=noninteractive
-
-get_go() {
-    echo "\nInstalling Go ...\n"
-    # install golang per https://golang.org/doc/install#tarball
-    curl -kL https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
-        | tar -C /usr/local/ -xzf -
-}
-
-get_go_deps() {
-    echo "\nDowloading go dependencies ...\n"
-    # for generating Go client stubs from openapi.yaml
-    # GO111MODULE=on go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-}
 
 install_deps() {
     apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     && apt-get -y install curl git python-is-python3 python3-pip \
-    && get_go \
-    && python -m pip install --prefer-binary -r requirements.txt \
-    && get_go_deps
+    && python -m pip install --prefer-binary -r requirements.txt 
 }
 
 gen_artifacts() {

--- a/models/platform/open-traffic-generator-platform.yang
+++ b/models/platform/open-traffic-generator-platform.yang
@@ -14,7 +14,7 @@ module open-traffic-generator-platform {
   description
     "This module defines data related to open traffic generator (OTG) components";
 
-  revision 2022-01-21 {
+  revision 2024-04-22 {
     description
       "Initial revision";
     reference "0.1.0";
@@ -22,11 +22,11 @@ module open-traffic-generator-platform {
 
   grouping platform-top {
     description
-      "Top-level structural grouping for OTG component entries.";
+      "Top-level structural grouping for for components if an Open Traffic Generator compliant implementation.";
 
     container components {
       description
-        "components that are defined by an OTG.";
+        "Components which are part of an Open Traffic Generator compliant implementation.";
 
       list component {
         key "name";
@@ -34,7 +34,7 @@ module open-traffic-generator-platform {
         config false;
 
         description
-          "An individual component defined by an OTG.";
+          "An individual component of an OTG compliant implementation.";
 
         leaf name {
           type leafref {
@@ -66,7 +66,7 @@ module open-traffic-generator-platform {
         }
       }
       description
-        "An arbitrary name of an OTG component.";
+        "The name of the OTG component ";
     }
 
     leaf sw-version {

--- a/models/platform/open-traffic-generator-platform.yang
+++ b/models/platform/open-traffic-generator-platform.yang
@@ -1,0 +1,84 @@
+module open-traffic-generator-platform {
+  yang-version "1";
+
+  namespace "http://github.com/open-traffic-generator/models/yang/models/platform";
+  prefix "otg-platform";
+
+  import open-traffic-generator-types {
+    prefix "otg-types";
+  }
+
+  organization
+    "OpenTrafficGenerator working group";
+
+  contact
+    "OpenTrafficGenerator working group
+     opentrafficgenerator@googlegroups.com";
+
+  description
+    "This module defines data related to open traffic generator (OTG) components";
+
+  revision 2022-01-21 {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  grouping platform-top {
+    description
+      "Top-level structural grouping for OTG component entries.";
+
+    container components {
+      description
+        "components that are defined by an OTG.";
+
+      list component {
+        key "name";
+
+        config false;
+
+        description
+          "An individual component defined by an OTG.";
+
+        leaf name {
+          type leafref {
+            path "../state/name";
+          }
+          description
+            "Reference to an component's name, acting as a key of
+            the components list.";
+        }
+
+        container state {
+          description
+            "Operational state of an individual component.";
+          uses component-state;
+        }
+      }
+    }
+  }
+
+  grouping component-state {
+    description
+      "Operational state of an OTG component.";
+
+    leaf name {
+      type enumeration {
+        enum keng-controller {
+          description
+            "The OTG component is keng-controller.";
+        }
+      }
+      description
+        "An arbitrary name of an OTG component.";
+    }
+
+    leaf sw-version {
+      type string;
+      description
+        "Software version information of an OTG component";
+    }
+  }
+
+  uses platform-top;
+}

--- a/models/platform/open-traffic-generator-platform.yang
+++ b/models/platform/open-traffic-generator-platform.yang
@@ -22,7 +22,7 @@ module open-traffic-generator-platform {
 
   grouping platform-top {
     description
-      "Top-level structural grouping for for components if an Open Traffic Generator compliant implementation.";
+      "Top-level structural grouping for components if an Open Traffic Generator compliant implementation.";
 
     container components {
       description

--- a/models/platform/open-traffic-generator-platform.yang
+++ b/models/platform/open-traffic-generator-platform.yang
@@ -65,20 +65,21 @@ module open-traffic-generator-platform {
             "The keng-controller component of the OTG implementation.";
         }
 
-        enum sdk {
-          description
-            "The snappi/gosnappi sdk supported by the OTG implementation.";
-        }
-
       }
       description
         "The name of the OTG component ";
     }
 
-    leaf version {
+    leaf software-version {
       type string;
       description
-        "version information of an OTG component";
+        "Software version information of an OTG component";
+    }
+
+    leaf sdk-version {
+      type string;
+      description
+        "snappi/gosnappi version information of an OTG component";
     }
   }
 

--- a/models/platform/open-traffic-generator-platform.yang
+++ b/models/platform/open-traffic-generator-platform.yang
@@ -4,10 +4,6 @@ module open-traffic-generator-platform {
   namespace "http://github.com/open-traffic-generator/models/yang/models/platform";
   prefix "otg-platform";
 
-  import open-traffic-generator-types {
-    prefix "otg-types";
-  }
-
   organization
     "OpenTrafficGenerator working group";
 

--- a/models/platform/open-traffic-generator-platform.yang
+++ b/models/platform/open-traffic-generator-platform.yang
@@ -62,17 +62,23 @@ module open-traffic-generator-platform {
       type enumeration {
         enum keng-controller {
           description
-            "The OTG component is keng-controller.";
+            "The keng-controller component of the OTG implementation.";
         }
+
+        enum sdk {
+          description
+            "The snappi/gosnappi sdk supported by the OTG implementation.";
+        }
+
       }
       description
         "The name of the OTG component ";
     }
 
-    leaf sw-version {
+    leaf version {
       type string;
       description
-        "Software version information of an OTG component";
+        "version information of an OTG component";
     }
   }
 


### PR DESCRIPTION
### Supported Path:

**_keng-controller software and sdk version_**
/components/component[name=keng-controller]/
```
[
  {
    "source": "localhost:50051",
    "timestamp": 1713941716239834587,
    "time": "2024-04-24T06:55:16.239834587Z",
    "updates": [
      {
        "Path": "components/component[name=keng-controller]",
        "values": {
          "components/component": {
            "open-traffic-generator-platform:name": "keng-controller",
            "open-traffic-generator-platform:state": {
              "name": "keng-controller",
              "sdk-version": "1.3.0",
              "software-version": "1.3.0-2"
            }
          }
        }
      }
    ]
  }
]
```
