### PR TITLE
l1 tx/rx rates are added for flows

### DIFF
--- a/artifacts/open-traffic-generator-flow.txt
+++ b/artifacts/open-traffic-generator-flow.txt
@@ -10,6 +10,8 @@ module: open-traffic-generator-flow
         |  +--ro in-frame-rate?     otg-types:ieeefloat32
         |  +--ro out-rate?          otg-types:ieeefloat32
         |  +--ro in-rate?           otg-types:ieeefloat32
+        |  +--ro out-l1-rate?       otg-types:ieeefloat32
+        |  +--ro in-l1-rate?        otg-types:ieeefloat32
         |  +--ro minimum-latency?   otg-types:timeticks64
         |  +--ro maximum-latency?   otg-types:timeticks64
         |  +--ro average-latency?   otg-types:timeticks64

--- a/models/flow/open-traffic-generator-flow.yang
+++ b/models/flow/open-traffic-generator-flow.yang
@@ -128,6 +128,20 @@ module open-traffic-generator-flow {
         received.";
     }
 
+    leaf out-l1-rate {
+      type otg-types:ieeefloat32;
+      description
+        "The rate, measured in bits per second, at which the flow is being
+        transmitted from the Layer 1.";
+    }
+
+    leaf in-l1-rate {
+      type otg-types:ieeefloat32;
+      description
+        "The rate, measured in bits per second, at which the flow is being
+        received in the Layer 1.";
+    }
+
     leaf minimum-latency {
       type otg-types:timeticks64;
       description


### PR DESCRIPTION
module: open-traffic-generator-flow
  +--rw flows
     +--ro flow* [name]
        +--ro name              -> ../state/name
        +--ro state
        |  +--ro name?              string
        |  +--ro transmit?          boolean
        |  +--ro loss-pct?          otg-types:ieeefloat32
        |  +--ro out-frame-rate?    otg-types:ieeefloat32
        |  +--ro in-frame-rate?     otg-types:ieeefloat32
        |  +--ro out-rate?          otg-types:ieeefloat32
        |  +--ro in-rate?           otg-types:ieeefloat32
        |  +--ro out-l1-rate?       otg-types:ieeefloat32
        |  +--ro in-l1-rate?        otg-types:ieeefloat32
        |  +--ro minimum-latency?   otg-types:timeticks64
        |  +--ro maximum-latency?   otg-types:timeticks64
        |  +--ro average-latency?   otg-types:timeticks64
        |  +--ro first-timestamp?   decimal64
        |  +--ro last-timestamp?    decimal64
        |  +--ro counters
        |     +--ro in-octets?    otg-types:counter64
        |     +--ro in-pkts?      otg-types:counter64
        |     +--ro out-octets?   otg-types:counter64
        |     +--ro out-pkts?     otg-types:counter64
        +--ro tagged-metrics
           +--ro tagged-metric* [name-value-pairs]
              +--ro name-value-pairs    -> ../state/name-value-pairs
              +--ro state
                 +--ro name-value-pairs?   string
                 +--ro tags* []
                 |  +--ro tag-name?    string
                 |  +--ro tag-value
                 |     +--ro value-type?           enumeration
                 |     +--ro value-as-string?      string
                 |     +--ro value-as-hex?         otg-types:hex-string
                 |     +--ro value-as-bool?        boolean
                 |     +--ro value-as-counter64?   otg-types:counter64
                 |     +--ro value-as-float32?     otg-types:ieeefloat32
                 |     +--ro value-as-ipv4?        otg-types:ipv4-address
                 |     +--ro value-as-ipv6?        otg-types:ipv6-address
                 |     +--ro value-as-mac?         otg-types:mac-address
                 +--ro counters
                    +--ro in-octets?    otg-types:counter64
                    +--ro in-pkts?      otg-types:counter64
                    +--ro out-octets?   otg-types:counter64
                    +--ro out-pkts?     otg-types:counter64